### PR TITLE
feat: Split out power management functionality

### DIFF
--- a/internal/messaging/redis.go
+++ b/internal/messaging/redis.go
@@ -7,8 +7,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/redis/go-redis/v9"
 	"vehicle-service/internal/types"
+
+	"github.com/redis/go-redis/v9"
 )
 
 type Callbacks struct {
@@ -563,6 +564,20 @@ func (r *RedisClient) SetHandlebarLockState(isLocked bool) error {
 		return err
 	}
 	r.logger.Printf("Successfully set handlebar lock state")
+	return nil
+}
+
+// PublishPowerCommand publishes a power command to the scooter:power channel
+func (r *RedisClient) PublishPowerCommand(command string) error {
+	r.logger.Printf("Publishing power command: %s", command)
+
+	// Publish the command to the scooter:power channel
+	err := r.client.Publish(r.ctx, "scooter:power", command).Err()
+	if err != nil {
+		r.logger.Printf("Failed to publish power command: %v", err)
+		return err
+	}
+	r.logger.Printf("Successfully published power command")
 	return nil
 }
 


### PR DESCRIPTION
Power management removed from the vehicle-service, it will communicate power management requests to the [pm-service](https://github.com/librescoot/pm-service) via Redis instead:

- Removed the handlePowerRequest function and its registration, eliminating direct systemctl calls for hibernate and reboot from vehicle-service.
- Removed the "lock-hibernate" case's direct call to the removed power handling logic.
- Updated the "lock-hibernate" case in handleStateRequest to publish a "hibernate-manual" command to the scooter:power Redis channel, allowing the pm-service to initiate the hibernate process.
- Added a PublishPowerCommand method to the messaging.RedisClient to facilitate sending power commands to the scooter:power channel.
- The Shutdown function was updated to focus solely on resource cleanup, as system power state changes are now the responsibility of the pm-service.

The vehicle-service retains control over vehicle-specific power outputs (dashboard, engine) within its state transitions.