### PR TITLE
feat: Add Redis LPUSH commands for LED control

### DIFF
--- a/internal/core/system.go
+++ b/internal/core/system.go
@@ -63,6 +63,8 @@ func (v *VehicleSystem) Start() error {
 		BlinkerCallback:   v.handleBlinkerRequest,
 		PowerCallback:     v.handlePowerRequest,
 		StateCallback:     v.handleStateRequest,
+		LedCueCallback:    v.handleLedCueRequest,
+		LedFadeCallback:   v.handleLedFadeRequest,
 	})
 
 	if err := v.redis.Connect(); err != nil {
@@ -902,7 +904,7 @@ func (v *VehicleSystem) handleStateRequest(state string) error {
 		if currentState == types.StateParked {
 			return v.transitionTo(types.StateStandby)
 		} else {
-			return fmt.Errorf("Vehicle must be parked to lock")
+			return fmt.Errorf("vehicle must be parked to lock")
 		}
 	case "lock-hibernate":
 		if currentState == types.StateParked {
@@ -918,9 +920,19 @@ func (v *VehicleSystem) handleStateRequest(state string) error {
 			}()
 			return nil
 		} else {
-			return fmt.Errorf("Vehicle must be parked to lock")
+			return fmt.Errorf("vehicle must be parked to lock")
 		}
 	default:
 		return fmt.Errorf("invalid state request: %s", state)
 	}
+}
+
+func (v *VehicleSystem) handleLedCueRequest(cueIndex int) error {
+	v.logger.Printf("Handling LED cue request: %d", cueIndex)
+	return v.io.PlayPwmCue(cueIndex)
+}
+
+func (v *VehicleSystem) handleLedFadeRequest(ledChannel int, fadeIndex int) error {
+	v.logger.Printf("Handling LED fade request: channel=%d, index=%d", ledChannel, fadeIndex)
+	return v.io.PlayPwmFade(ledChannel, fadeIndex)
 }

--- a/internal/hardware/io.go
+++ b/internal/hardware/io.go
@@ -381,6 +381,10 @@ func (io *LinuxHardwareIO) PlayPwmCue(idx int) error {
 	return io.pwmLed.PlayCue(idx)
 }
 
+func (io *LinuxHardwareIO) PlayPwmFade(ch int, idx int) error {
+	return io.pwmLed.PlayFade(ch, idx)
+}
+
 func (io *LinuxHardwareIO) Cleanup() {
 	close(io.stopChan)
 

--- a/internal/hardware/leds.go
+++ b/internal/hardware/leds.go
@@ -3,18 +3,17 @@ package hardware
 import (
 	"encoding/binary"
 	"fmt"
-	"golang.org/x/sys/unix"
 	"io"
 	"log"
 	"os"
 	"sync"
 	"syscall"
 	"time"
+
+	"golang.org/x/sys/unix"
 )
 
 const (
-	pwmLedIocType = 'u'
-
 	pwmLedConfigure = 0x00007540 // _IO('u', 0x40)
 	pwmLedOpenFade  = 0x00007541 // _IO('u', 0x41)
 	pwmLedOpenCue   = 0x00007542 // _IO('u', 0x42)
@@ -52,12 +51,6 @@ type CueAction struct {
 	LED   uint8         // 5 bits
 	Type  CueActionType // 4 bits
 	Value uint16        // 16 bits
-}
-
-func encodeCueAction(action CueAction) uint32 {
-	return uint32(action.LED&0x1F) |
-		(uint32(action.Type&0x0F) << 8) |
-		(uint32(action.Value) << 16)
 }
 
 type LedDevice struct {


### PR DESCRIPTION
Implement Redis LPUSH commands for triggering LED fades and cues:
- Add LedCueCallback and LedFadeCallback to the messaging system
- Add handlers for scooter:led:cue and scooter:led:fade LPUSH commands
- Connect the functionality to the existing PWM LED implementation
- Add PlayPwmFade method to hardware IO

Implements #1.