### PR TITLE
feat: move all power responsibilities from vehicle-service to pm-service

### DIFF
--- a/internal/hardware/constants.go
+++ b/internal/hardware/constants.go
@@ -18,8 +18,6 @@ var DoMappings = map[string]struct {
 	"seatbox_lock":         {2, 10},
 	"horn":                 {2, 9},
 	"engine_brake":         {2, 11},
-	"engine_power":         {2, 17},
-	"dashboard_power":      {1, 18},
 	"handlebar_lock_close": {4, 6},
 	"handlebar_lock_open":  {4, 7},
 }

--- a/internal/hardware/constants.go
+++ b/internal/hardware/constants.go
@@ -20,4 +20,6 @@ var DoMappings = map[string]struct {
 	"engine_brake":         {2, 11},
 	"handlebar_lock_close": {4, 6},
 	"handlebar_lock_open":  {4, 7},
+	"dashboard_power":      {1, 18},
+	"engine_power":         {2, 17},
 }

--- a/internal/messaging/redis.go
+++ b/internal/messaging/redis.go
@@ -18,13 +18,11 @@ type Callbacks struct {
 	SeatboxCallback   func(bool) error   // true for "on", false for "off"
 	HornCallback      func(bool) error   // true for "on", false for "off"
 	BlinkerCallback   func(string) error // "off", "left", "right", "both"
-	PowerCallback     func(string) error // "hibernate-manual", "reboot"
 	StateCallback     func(string) error // "unlock", "lock", "lock-hibernate"
 	ForceLockCallback func() error       // New callback for force-lock
 	LedCueCallback    func(int) error
 	LedFadeCallback   func(int, int) error
 	UpdateCallback    func(string) error // "start", "complete"
-	GovernorCallback  func(string) error // "ondemand", "powersave", "performance"
 }
 
 type RedisClient struct {
@@ -87,16 +85,14 @@ func (r *RedisClient) StartListening() error {
 	go r.redisListener(pubsub)
 
 	// Start list command listeners for LPUSH commands
-	r.wg.Add(9)
+	r.wg.Add(7)
 	go r.listCommandListener("scooter:seatbox", r.handleSeatboxCommand)
 	go r.listCommandListener("scooter:horn", r.handleHornCommand)
 	go r.listCommandListener("scooter:blinker", r.handleBlinkerCommand)
-	go r.listCommandListener("scooter:power", r.handlePowerCommand)
 	go r.listCommandListener("scooter:state", r.handleStateCommand)
 	go r.listCommandListener("scooter:led:cue", r.handleLedCueCommand)
 	go r.listCommandListener("scooter:led:fade", r.handleLedFadeCommand)
 	go r.listCommandListener("scooter:update", r.handleUpdateCommand)
-	go r.listCommandListener("scooter:governor", r.handleGovernorCommand)
 
 	return nil
 }
@@ -182,18 +178,6 @@ func (r *RedisClient) handleBlinkerCommand(value string) error {
 	}
 }
 
-func (r *RedisClient) handlePowerCommand(value string) error {
-	if r.callbacks.PowerCallback == nil {
-		return nil
-	}
-	switch value {
-	case "hibernate-manual", "reboot":
-		return r.callbacks.PowerCallback(value)
-	default:
-		r.logger.Printf("Invalid power command value: %s", value)
-		return fmt.Errorf("invalid power command: %s", value)
-	}
-}
 
 func (r *RedisClient) handleStateCommand(value string) error {
 	if r.callbacks.StateCallback == nil && r.callbacks.ForceLockCallback == nil {
@@ -256,21 +240,6 @@ func (r *RedisClient) handleUpdateCommand(value string) error {
 }
 
 // handleGovernorCommand processes CPU governor change requests
-func (r *RedisClient) handleGovernorCommand(value string) error {
-	if r.callbacks.GovernorCallback == nil {
-		return nil
-	}
-
-	r.logger.Printf("Processing governor change request: %s", value)
-
-	switch value {
-	case "ondemand", "powersave", "performance":
-		return r.callbacks.GovernorCallback(value)
-	default:
-		r.logger.Printf("Invalid governor command value: %s", value)
-		return fmt.Errorf("invalid governor command: %s", value)
-	}
-}
 
 func (r *RedisClient) redisListener(pubsub *redis.PubSub) {
 	defer r.wg.Done()
@@ -351,17 +320,6 @@ func (r *RedisClient) redisListener(pubsub *redis.PubSub) {
 					}
 				}
 
-			case "scooter:power":
-				if r.callbacks.PowerCallback != nil {
-					switch msg.Payload {
-					case "hibernate-manual", "reboot":
-						if err := r.callbacks.PowerCallback(msg.Payload); err != nil {
-							r.logger.Printf("Failed to handle power request: %v", err)
-						}
-					default:
-						r.logger.Printf("Invalid power request value: %s", msg.Payload)
-					}
-				}
 
 			case "scooter:update":
 				if r.callbacks.UpdateCallback != nil {
@@ -375,17 +333,6 @@ func (r *RedisClient) redisListener(pubsub *redis.PubSub) {
 					}
 				}
 
-			case "scooter:governor":
-				if r.callbacks.GovernorCallback != nil {
-					switch msg.Payload {
-					case "ondemand", "powersave", "performance":
-						if err := r.callbacks.GovernorCallback(msg.Payload); err != nil {
-							r.logger.Printf("Failed to handle governor request: %v", err)
-						}
-					default:
-						r.logger.Printf("Invalid governor request value: %s", msg.Payload)
-					}
-				}
 
 			case "vehicle":
 				// msg.Payload contains the hash field that changed
@@ -408,12 +355,8 @@ func (r *RedisClient) processVehicleMessage(payload string) {
 		handler = r.handleHornCommand
 	case "scooter:blinker":
 		handler = r.handleBlinkerCommand
-	case "scooter:power":
-		handler = r.handlePowerCommand
 	case "scooter:update":
 		handler = r.handleUpdateCommand
-	case "scooter:governor":
-		handler = r.handleGovernorCommand
 	default:
 		// Ignore unknown payloads to keep behaviour predictable
 		r.logger.Printf("Unhandled vehicle payload: %s", payload)
@@ -760,6 +703,17 @@ func (r *RedisClient) GetOtaStatus(component string) (string, error) {
 		return "", fmt.Errorf("failed to get OTA status for component %s: %w", component, err)
 	}
 	return status, nil
+}
+
+// SendCommand sends a command to a Redis list (for communication with other services)
+func (r *RedisClient) SendCommand(channel, command string) error {
+	err := r.client.LPush(r.ctx, channel, command).Err()
+	if err != nil {
+		r.logger.Printf("Failed to send command '%s' to channel '%s': %v", command, channel, err)
+		return err
+	}
+	r.logger.Printf("Sent command '%s' to channel '%s'", command, channel)
+	return nil
 }
 
 func (r *RedisClient) Close() error {


### PR DESCRIPTION
Power management removed from the vehicle-service, it will communicate power management requests to the [pm-service](https://github.com/librescoot/pm-service) via Redis instead.

cf https://github.com/librescoot/pm-service/pull/1