### PR TITLE
feat(hibernation): manual multi-step hibernation with safety checks

### DIFF
--- a/internal/messaging/redis.go
+++ b/internal/messaging/redis.go
@@ -798,22 +798,6 @@ func (r *RedisClient) GetHashField(hash, field string) (string, error) {
 	return value, nil
 }
 
-// PublishHibernationState publishes hibernation state to Redis
-func (r *RedisClient) PublishHibernationState(state string, timeRemaining int) error {
-	// Set hibernation state and time remaining
-	if err := r.client.HSet(r.ctx, "hibernation", "state", state).Err(); err != nil {
-		return fmt.Errorf("failed to set hibernation state: %w", err)
-	}
-	if err := r.client.HSet(r.ctx, "hibernation", "time_remaining", timeRemaining).Err(); err != nil {
-		return fmt.Errorf("failed to set hibernation time remaining: %w", err)
-	}
-	// Publish state change notification
-	if err := r.client.Publish(r.ctx, "hibernation", "state-change").Err(); err != nil {
-		return fmt.Errorf("failed to publish hibernation state change: %w", err)
-	}
-	return nil
-}
-
 func (r *RedisClient) Close() error {
 	r.logger.Infof("Closing Redis client")
 	r.cancel()


### PR DESCRIPTION
## Summary

Implements a multi-step manual hibernation flow for the vehicle service that provides user confirmation and safety checks before entering low-power hibernation mode.

### Key Features

- **Multi-state confirmation flow**: Initial 15s brake hold → waiting state → 3s final confirmation
- **Force hibernation**: 30s continuous hold or 15s re-hold automatically confirms (warehouse mode)
- **Safety checks**: Validates kickstand down and seatbox closed before hibernation
- **User-friendly feedback**: Vehicle states (`waiting-hibernation`, `waiting-hibernation-seatbox`, `waiting-hibernation-confirm`) allow UI to show progress
- **Timeout handling**: 30s timeout if no brake activity during confirmation phase
- **Keycard confirmation**: Tap keycard during confirmation to immediately proceed

### State Machine Flow

1. **Initial Hold (15s)**: Both brakes held in parked state
2. **Waiting State**: Vehicle enters `waiting-hibernation`, ready for confirmation
3. **Confirmation Options**:
   - Keycard tap (requires seatbox closed)
   - 30s continuous hold total (auto-confirm, skips seatbox check)
   - Release + 15s re-hold (auto-confirm, skips seatbox check)
4. **Final Confirmation (3s)**: Non-abortable countdown in `waiting-hibernation-confirm`
5. **Execution**: Transitions to shutting-down → standby → hibernation command to pm-service

### Implementation Details

- Added `HibernationManager` state machine to coordinate hibernation flow
- New vehicle states: `waiting-hibernation`, `waiting-hibernation-seatbox`, `waiting-hibernation-confirm`
- Refactored brake/keycard handling for cleaner hibernation integration
- Extracted Redis publishing helpers for consistency
- Consolidated keycode mapping into single source of truth

### Changes

- **internal/core/system.go**: HibernationManager state machine, multi-step confirmation logic
- **internal/types/state.go**: New hibernation-related states
- **internal/hardware/io.go**: Keycode consolidation
- **internal/messaging/redis.go**: Redis helper extraction