### PR TITLE
Add auto-standby feature

### DIFF
--- a/internal/core/state_transitions.go
+++ b/internal/core/state_transitions.go
@@ -36,6 +36,11 @@ func (v *VehicleSystem) transitionTo(newState types.SystemState) error {
 		return fmt.Errorf("failed to publish state: %w", err)
 	}
 
+	// Cancel auto-standby timer when leaving parked state
+	if oldState == types.StateParked && newState != types.StateParked {
+		v.cancelAutoStandbyTimer()
+	}
+
 	v.logger.Debugf("Applying state transition effects for %s", newState)
 	switch newState {
 
@@ -123,6 +128,9 @@ func (v *VehicleSystem) transitionTo(newState types.SystemState) error {
 				v.playLedCue(1, "standby to parked brake off")
 			}
 		}
+
+	// Start auto-standby timer when entering parked state
+	v.startAutoStandbyTimer()
 
 	case types.StateStandby:
 		v.mu.Lock()

--- a/internal/messaging/redis.go
+++ b/internal/messaging/redis.go
@@ -717,6 +717,22 @@ func (r *RedisClient) PublishButtonEvent(event string) error {
 	return nil
 }
 
+// PublishAutoStandbyCountdown publishes the auto-standby countdown to Redis
+func (r *RedisClient) PublishAutoStandbyCountdown(remaining int) error {
+	if err := r.publishHashSet("vehicle", "auto-standby-remaining", remaining, "vehicle", "auto-standby-remaining"); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ClearAutoStandbyCountdown removes the auto-standby countdown from Redis
+func (r *RedisClient) ClearAutoStandbyCountdown() error {
+	if err := r.publishHashDel("vehicle", "auto-standby-remaining", "vehicle", "auto-standby-remaining"); err != nil {
+		return err
+	}
+	return nil
+}
+
 // PublishGovernorChange publishes a governor change event to Redis
 func (r *RedisClient) PublishGovernorChange(governor string) error {
 	r.logger.Debugf("Publishing governor change: %s", governor)


### PR DESCRIPTION
Implements configurable auto-standby timer that transitions vehicle to standby after a period of inactivity in parked state.

## Changes

- Add scooter.auto-standby-seconds setting (0 = disabled, default)
- Start timer when entering parked state, cancel when leaving
- Reset timer on physical interaction (brake press, kickstand movement, seatbox button)
- Publish countdown to Redis every second for UI consumption
- Transition to standby via shutting-down state when timer expires

## Related

- Requires librescoot/scootui#86

## Testing

Enable with: redis-cli HSET settings scooter.auto-standby-seconds 300