### PR TITLE
feat: set suspend-only inhibitor during DBC updates

### DIFF
--- a/internal/core/fsm_actions.go
+++ b/internal/core/fsm_actions.go
@@ -367,15 +367,31 @@ func (v *VehicleSystem) EnterShuttingDown(c *librefsm.Context) error {
 	// Ask DBC to shut down cleanly via Redis PUBSUB.
 	// dbc-dispatcher on the DBC executes the poweroff.
 	// GPIO cut in EnterStandby (10s later) is the hard backstop.
+	//
+	// If a DBC update is in progress, skip the poweroff so the DBC can keep
+	// updating during standby. But if hibernation was requested, the MDB is
+	// about to power off and the DBC will lose power anyway, so shut it down
+	// cleanly instead of deferring.
 	v.mu.RLock()
 	updating := v.dbcUpdating
+	hibernating := v.hibernationRequest
 	v.mu.RUnlock()
-	if !updating {
+	if !updating || hibernating {
+		if updating && hibernating {
+			v.logger.Infof("Hibernate requested, forcing DBC shutdown despite active update")
+			v.mu.Lock()
+			v.dbcUpdating = false
+			v.deferredDashboardPower = nil
+			v.mu.Unlock()
+			if err := v.redis.RemoveInhibitor("dbc-update"); err != nil {
+				v.logger.Warnf("Failed to remove DBC update inhibitor: %v", err)
+			}
+		}
 		if err := v.redis.PublishMessage("dbc:command", "poweroff"); err != nil {
 			v.logger.Warnf("Failed to send DBC poweroff: %v", err)
 		}
 	} else {
-		v.logger.Infof("Skipping DBC poweroff — DBC update in progress")
+		v.logger.Infof("Skipping DBC poweroff, update in progress")
 	}
 
 	return nil

--- a/internal/core/interfaces.go
+++ b/internal/core/interfaces.go
@@ -29,6 +29,10 @@ type MessagingClient interface {
 	SetDbcUpdating(updating bool) error
 	GetOtaStatus(component string) (string, error)
 
+	// Power inhibitors
+	SetInhibitor(id, inhibitType, why string) error
+	RemoveInhibitor(id string) error
+
 	// Settings
 	GetHashField(hash, field string) (string, error)
 

--- a/internal/core/redis_handlers.go
+++ b/internal/core/redis_handlers.go
@@ -196,6 +196,11 @@ func (v *VehicleSystem) handleUpdateRequest(action string) error {
 			v.logger.Warnf("Failed to persist DBC updating state to Redis: %v", err)
 		}
 
+		// Keep MDB awake during standby while DBC is updating
+		if err := v.redis.SetInhibitor("dbc-update", "suspend-only", "DBC update in progress"); err != nil {
+			v.logger.Warnf("Failed to set DBC update inhibitor: %v", err)
+		}
+
 		// Ensure dashboard is powered on
 		if err := v.setPower("dashboard_power", true); err != nil {
 			v.logger.Errorf("%v for DBC update", err)
@@ -220,6 +225,11 @@ func (v *VehicleSystem) handleUpdateRequest(action string) error {
 		// Persist to Redis
 		if err := v.redis.SetDbcUpdating(false); err != nil {
 			v.logger.Warnf("Failed to persist DBC updating state to Redis: %v", err)
+		}
+
+		// Remove suspend-only inhibitor now that DBC update is done
+		if err := v.redis.RemoveInhibitor("dbc-update"); err != nil {
+			v.logger.Warnf("Failed to remove DBC update inhibitor: %v", err)
 		}
 
 		// Handle deferred power-on request
@@ -510,6 +520,11 @@ func (v *VehicleSystem) handleDbcUpdateTimeout() {
 	// Persist to Redis
 	if err := v.redis.SetDbcUpdating(false); err != nil {
 		v.logger.Warnf("Failed to persist DBC updating state to Redis after timeout: %v", err)
+	}
+
+	// Remove suspend-only inhibitor on timeout
+	if err := v.redis.RemoveInhibitor("dbc-update"); err != nil {
+		v.logger.Warnf("Failed to remove DBC update inhibitor after timeout: %v", err)
 	}
 
 	// Apply deferred power state or default behavior (same logic as complete-dbc)

--- a/internal/core/system.go
+++ b/internal/core/system.go
@@ -220,7 +220,7 @@ func (v *VehicleSystem) Start() error {
 	dbcStatus, err := v.redis.GetOtaStatus("dbc")
 	if err != nil {
 		v.logger.Warnf("Failed to get DBC OTA status on startup: %v", err)
-	} else if dbcStatus == "downloading" || dbcStatus == "installing" || dbcStatus == "rebooting" {
+	} else if dbcStatus == "downloading" || dbcStatus == "preparing" || dbcStatus == "installing" || dbcStatus == "pending-reboot" {
 		v.logger.Infof("DBC update in progress on startup (status=%s), restoring dbcUpdating flag", dbcStatus)
 		if !restoreDbcUpdate {
 			// Sync the Redis flag if it wasn't already set
@@ -250,6 +250,16 @@ func (v *VehicleSystem) Start() error {
 		})
 		v.mu.Unlock()
 		v.logger.Infof("DBC update timeout set to %v (restored on startup)", dbcUpdateTimeout)
+
+		// Re-set suspend-only inhibitor so pm-service keeps MDB awake during DBC update
+		if err := v.redis.SetInhibitor("dbc-update", "suspend-only", "DBC update in progress (restored on startup)"); err != nil {
+			v.logger.Warnf("Failed to set DBC update inhibitor on startup: %v", err)
+		}
+	} else {
+		// Not restoring DBC update, clean up any stale inhibitor from a previous run
+		if err := v.redis.RemoveInhibitor("dbc-update"); err != nil {
+			v.logger.Warnf("Failed to remove stale DBC update inhibitor on startup: %v", err)
+		}
 	}
 
 	// Read dashboard power from Redis BEFORE hardware initialization

--- a/internal/core/system_test.go
+++ b/internal/core/system_test.go
@@ -54,6 +54,8 @@ func (m *mockMessagingClient) DeleteDashboardReadyFlag() error                { 
 func (m *mockMessagingClient) GetDbcUpdating() (bool, error)                  { return m.dbcUpdating, nil }
 func (m *mockMessagingClient) SetDbcUpdating(updating bool) error             { m.dbcUpdating = updating; return nil }
 func (m *mockMessagingClient) GetOtaStatus(component string) (string, error)  { return m.otaStatus, nil }
+func (m *mockMessagingClient) SetInhibitor(id, inhibitType, why string) error { return nil }
+func (m *mockMessagingClient) RemoveInhibitor(id string) error                { return nil }
 func (m *mockMessagingClient) GetHashField(hash, field string) (string, error) { return m.hashFieldValue, nil }
 func (m *mockMessagingClient) PublishAutoStandbyDeadline(deadline time.Time) error { return nil }
 func (m *mockMessagingClient) ClearAutoStandbyDeadline() error                { return nil }

--- a/internal/messaging/redis.go
+++ b/internal/messaging/redis.go
@@ -2,6 +2,7 @@ package messaging
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
@@ -693,6 +694,68 @@ func (r *RedisClient) GetHashField(hash, field string) (string, error) {
 		return "", nil
 	}
 	return value, nil
+}
+
+const (
+	inhibitHashKey = "power:inhibits"
+	inhibitChannel = "power:inhibits"
+)
+
+// inhibitData matches the JSON schema that pm-service reads from the power:inhibits hash
+type inhibitData struct {
+	ID       string `json:"id"`
+	Who      string `json:"who"`
+	What     string `json:"what"`
+	Why      string `json:"why"`
+	Type     string `json:"type"`
+	Duration int64  `json:"duration"`
+	Created  int64  `json:"created"`
+}
+
+// SetInhibitor writes a power inhibitor to the power:inhibits Redis hash and notifies pm-service
+func (r *RedisClient) SetInhibitor(id, inhibitType, why string) error {
+	r.logger.Infof("Setting power inhibitor: id=%s, type=%s", id, inhibitType)
+
+	data := inhibitData{
+		ID:       id,
+		Who:      "vehicle-service",
+		What:     "power-state-change",
+		Why:      why,
+		Type:     inhibitType,
+		Duration: 0,
+		Created:  time.Now().Unix(),
+	}
+
+	jsonBytes, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("failed to marshal inhibitor data: %w", err)
+	}
+
+	if err := r.client.HSet(inhibitHashKey, id, string(jsonBytes)); err != nil {
+		return fmt.Errorf("failed to set inhibitor in Redis: %w", err)
+	}
+
+	if _, err := r.client.Publish(inhibitChannel, fmt.Sprintf("add:%s", id)); err != nil {
+		r.logger.Warnf("Failed to publish inhibitor add notification: %v", err)
+	}
+
+	return nil
+}
+
+// RemoveInhibitor removes a power inhibitor from the power:inhibits Redis hash and notifies pm-service
+func (r *RedisClient) RemoveInhibitor(id string) error {
+	r.logger.Infof("Removing power inhibitor: id=%s", id)
+
+	raw := r.client.Raw()
+	if err := raw.HDel(context.Background(), inhibitHashKey, id).Err(); err != nil {
+		return fmt.Errorf("failed to remove inhibitor from Redis: %w", err)
+	}
+
+	if _, err := r.client.Publish(inhibitChannel, fmt.Sprintf("remove:%s", id)); err != nil {
+		r.logger.Warnf("Failed to publish inhibitor remove notification: %v", err)
+	}
+
+	return nil
 }
 
 func (r *RedisClient) Close() error {


### PR DESCRIPTION
## Summary

vehicle-service now writes a `suspend-only` power inhibitor to the `power:inhibits` Redis hash when `dbcUpdating` is set. This keeps the MDB awake during standby while the DBC is updating, without blocking user-initiated hibernate.

When hibernate is requested while a DBC update is running, the update state is cleared and the DBC is shut down cleanly during the normal ShuttingDown phase. The DBC gets the full grace period before the MDB powers off, instead of getting a hard power cut.

Also recognizes the new `preparing` and `pending-reboot` OTA status values in the startup fallback check.

## Changes

- `start-dbc` handler: sets `suspend-only` inhibitor with id `dbc-update`
- `complete-dbc` handler: removes the inhibitor
- `handleDbcUpdateTimeout`: removes inhibitor on 45-minute safety timeout
- Startup recovery: re-sets inhibitor if `dbcUpdating` is restored, removes stale inhibitor otherwise
- `EnterShuttingDown`: if both `dbcUpdating` and `hibernationRequest` are true, clears the update state and shuts down the DBC normally instead of deferring
- OTA status check now handles `preparing` and `pending-reboot` alongside existing values
- New `SetInhibitor()`/`RemoveInhibitor()` methods on the Redis client

## Context

The DBC is only powered during unlocked states (parked, ready-to-drive) and during updates in standby. During standby, the `suspend-only` inhibitor keeps the MDB awake so the DBC can finish updating. But if the user triggers hibernate, the MDB is about to power off and the DBC would lose power regardless. Better to shut it down cleanly and let the update retry next time.

## Related PRs

- librescoot/pm-service#4 (adds the suspend-only inhibitor type)
- librescoot/update-service#13 (drops DBC inhibitors, vehicle-service handles it)
- librescoot/scootui-qt#3 (UI changes)

## Test plan

- [x] Build passes
- [x] Unit tests pass
- [ ] Inhibitor appears in `power:inhibits` hash when DBC update starts
- [ ] Inhibitor removed on `complete-dbc`
- [ ] Inhibitor removed on 45-minute timeout
- [ ] Startup recovery re-sets inhibitor if dbcUpdating was persisted
- [ ] Hibernate during DBC update: DBC gets poweroff command, update state cleared, GPIO cut proceeds normally