### PR TITLE
refactor: remove dual state, use FSM directly

### DIFF
--- a/internal/core/fsm_actions.go
+++ b/internal/core/fsm_actions.go
@@ -83,14 +83,10 @@ func (v *VehicleSystem) initFSM(ctx context.Context) error {
 	}
 	v.machine = machine
 
-	// Set up state change callback to sync legacy state field and publish
+	// Set up state change callback to publish state and manage governor
 	v.machine.OnStateChange(func(from, to librefsm.StateID) {
 		newState := stateIDToSystemState(to)
 		oldState := stateIDToSystemState(from)
-
-		v.mu.Lock()
-		v.state = newState
-		v.mu.Unlock()
 
 		// Request CPU governor change when leaving standby
 		if oldState == types.StateStandby && newState != types.StateStandby {

--- a/internal/core/redis_handlers.go
+++ b/internal/core/redis_handlers.go
@@ -219,8 +219,9 @@ func (v *VehicleSystem) handleUpdateRequest(action string) error {
 		v.dbcUpdating = false
 		deferredPower := v.deferredDashboardPower
 		v.deferredDashboardPower = nil
-		currentState := v.state
 		v.mu.Unlock()
+
+		currentState := v.getCurrentState()
 
 		// Persist to Redis
 		if err := v.redis.SetDbcUpdating(false); err != nil {
@@ -447,8 +448,9 @@ func (v *VehicleSystem) handleSettingsUpdate(settingKey string) error {
 		v.mu.Lock()
 		oldSeconds := v.autoStandbySeconds
 		v.autoStandbySeconds = seconds
-		currentState := v.state
 		v.mu.Unlock()
+
+		currentState := v.getCurrentState()
 
 		if seconds > 0 {
 			v.logger.Infof("Auto-standby enabled via settings update: %d seconds", seconds)
@@ -512,8 +514,9 @@ func (v *VehicleSystem) handleDbcUpdateTimeout() {
 	v.dbcUpdateTimer = nil
 	deferredPower := v.deferredDashboardPower
 	v.deferredDashboardPower = nil
-	currentState := v.state
 	v.mu.Unlock()
+
+	currentState := v.getCurrentState()
 
 	v.logger.Warnf("DBC update timeout - clearing dbcUpdating flag and applying deferred power state")
 

--- a/internal/core/state_transitions.go
+++ b/internal/core/state_transitions.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/librescoot/librefsm"
 
+	"vehicle-service/internal/fsm"
 	"vehicle-service/internal/types"
 )
 
@@ -203,9 +204,7 @@ func (v *VehicleSystem) handleHandlebarPosition(channel string, value bool) erro
 // updateEngineBrake updates only the engine brake based on current state
 // Used when brake lever state changes but vehicle state hasn't
 func (v *VehicleSystem) updateEngineBrake() error {
-	v.mu.RLock()
-	currentState := v.state
-	v.mu.RUnlock()
+	currentState := v.getCurrentState()
 
 	// Read current brake states
 	brakeLeft, err := v.io.ReadDigitalInput("brake_left")
@@ -234,20 +233,18 @@ func (v *VehicleSystem) updateEngineBrake() error {
 	return nil
 }
 
-// getCurrentState returns the current state (thread-safe) using FSM
+// getCurrentState returns the current state (thread-safe) by querying the FSM
 func (v *VehicleSystem) getCurrentState() types.SystemState {
-	if v.machine != nil {
-		return stateIDToSystemState(v.machine.CurrentState())
+	if v.machine == nil {
+		return types.StateInit
 	}
-	v.mu.RLock()
-	defer v.mu.RUnlock()
-	return v.state
+	return stateIDToSystemState(v.machine.CurrentState())
 }
 
 // getCurrentStateID returns the current FSM state ID
 func (v *VehicleSystem) getCurrentStateID() librefsm.StateID {
-	if v.machine != nil {
-		return v.machine.CurrentState()
+	if v.machine == nil {
+		return fsm.StateInit
 	}
-	return systemStateToStateID(v.state)
+	return v.machine.CurrentState()
 }

--- a/internal/core/system.go
+++ b/internal/core/system.go
@@ -45,7 +45,6 @@ const (
 )
 
 type VehicleSystem struct {
-	state                   types.SystemState
 	dashboardReady          bool
 	logger                  *logger.Logger
 	io                      HardwareIO
@@ -80,7 +79,6 @@ type VehicleSystem struct {
 
 func NewVehicleSystem(io HardwareIO, redis MessagingClient, l *logger.Logger) *VehicleSystem {
 	vs := &VehicleSystem{
-		state:                   types.StateInit,
 		logger:                  l.WithTag("Vehicle"),
 		io:                      io,
 		redis:                   redis,
@@ -769,9 +767,7 @@ func (v *VehicleSystem) handleInputChange(channel string, value bool) error {
 
 	case "brake_right", "brake_left":
 		// Control engine brake based on state
-		v.mu.RLock()
-		currentState := v.state
-		v.mu.RUnlock()
+		currentState := v.getCurrentState()
 
 		// Check if either brake is pressed after this change
 		brakeLeft, err := v.io.ReadDigitalInput("brake_left")

--- a/internal/core/system_test.go
+++ b/internal/core/system_test.go
@@ -185,8 +185,9 @@ func TestNewVehicleSystem(t *testing.T) {
 	if system.redis != mockRedis {
 		t.Error("redis not set correctly")
 	}
-	if system.state != types.StateInit {
-		t.Errorf("Expected initial state StateInit, got %v", system.state)
+	// Before FSM is initialized, machine is nil; verify the struct was constructed
+	if system.machine != nil {
+		t.Error("Expected machine to be nil before initFSM")
 	}
 }
 
@@ -547,9 +548,6 @@ func TestHardwareIOInputCallback(t *testing.T) {
 
 // ===== State Transition Tests =====
 // These tests verify the engine brake behavior during state transitions.
-// This was a regression where updateEngineBrake() was called at the end of
-// state entry actions, but it read v.state which hadn't been updated yet,
-// causing inverted engine brake behavior.
 
 // initTestFSM initializes the FSM for a test system
 func initTestFSM(t *testing.T, system *VehicleSystem) {


### PR DESCRIPTION
VehicleSystem had two parallel state representations: the `v.state` field and `v.machine.CurrentState()`. They were kept in sync via the `OnStateChange` callback, which worked fine but meant every state read had a choice of "which one do I use?" and the answer was always "doesn't matter, they're the same." That's one redundancy too many.

Removed `v.state` entirely. `getCurrentState()` now queries the FSM, with a nil guard for the brief window before `initFSM()` runs. The governor logic and Redis state publishing in `OnStateChange` stay as they were, just without the sync write.

~8 call sites updated across 5 files, net -10 lines.

Closes #14