### PR TITLE
feat(fsm): add hop-on / hop-off mode lockout

### DIFF
--- a/internal/core/fsm_actions.go
+++ b/internal/core/fsm_actions.go
@@ -39,6 +39,12 @@ func stateIDToSystemState(id librefsm.StateID) types.SystemState {
 		return types.StateWaitingHibernationSeatbox
 	case fsm.StateHibernationConfirm:
 		return types.StateWaitingHibernationConfirm
+	case fsm.StateHopOn:
+		// Externally hop-on looks like parked: the dashboard's `isParked()`
+		// check (used to allow opening the menu, learning, etc.) keeps
+		// working. Hop-on engagement is signalled separately via the
+		// `vehicle:hop-on-active` field.
+		return types.StateParked
 	default:
 		return types.SystemState(string(id))
 	}
@@ -262,21 +268,51 @@ func (v *VehicleSystem) EnterParked(c *librefsm.Context) error {
 		}
 	}
 
-	// Start auto-standby timer using librefsm
+	// Start (or resume) the auto-standby timer.
+	//
+	// When transitioning back from hop-on we resume from the saved
+	// deadline so a forgotten hop-on still drops to standby on the
+	// original schedule. handleHopOnRequest captures the live deadline
+	// just before sending EvHopOnEngage; ExitParked then clears the
+	// live one but the saved copy persists across the StateHopOn detour.
 	v.mu.RLock()
 	seconds := v.autoStandbySeconds
+	saved := v.hopOnSavedAutoStandbyDl
 	v.mu.RUnlock()
 
-	if seconds > 0 && v.machine != nil {
-		duration := time.Duration(seconds) * time.Second
-		v.machine.StartTimer(fsm.TimerAutoStandby, duration, librefsm.Event{ID: fsm.EvAutoStandbyTimeout})
-		v.logger.Infof("Started auto-standby timer: %d seconds", seconds)
+	cameFromHopOn := c.FromState == fsm.StateHopOn
 
-		// Publish the deadline time so UI can display countdown
-		deadline := time.Now().Add(duration)
+	if seconds > 0 && v.machine != nil {
+		var duration time.Duration
+		var deadline time.Time
+
+		if cameFromHopOn && !saved.IsZero() {
+			deadline = saved
+			duration = time.Until(deadline)
+			if duration < 1*time.Millisecond {
+				duration = 1 * time.Millisecond
+			}
+			v.logger.Infof("Resumed auto-standby timer with %v remaining (came from hop-on)", duration)
+		} else {
+			duration = time.Duration(seconds) * time.Second
+			deadline = time.Now().Add(duration)
+			v.logger.Infof("Started auto-standby timer: %d seconds", seconds)
+		}
+
+		v.mu.Lock()
+		v.autoStandbyDeadline = deadline
+		v.hopOnSavedAutoStandbyDl = time.Time{} // consumed (or stale — clear either way)
+		v.mu.Unlock()
+
+		v.machine.StartTimer(fsm.TimerAutoStandby, duration, librefsm.Event{ID: fsm.EvAutoStandbyTimeout})
 		if err := v.redis.PublishAutoStandbyDeadline(deadline); err != nil {
 			v.logger.Warnf("Failed to publish auto-standby deadline: %v", err)
 		}
+	} else {
+		// Even if no timer is armed, clear any stale saved deadline.
+		v.mu.Lock()
+		v.hopOnSavedAutoStandbyDl = time.Time{}
+		v.mu.Unlock()
 	}
 
 	return nil
@@ -429,6 +465,12 @@ func (v *VehicleSystem) ExitParked(c *librefsm.Context) error {
 	if err := v.redis.ClearAutoStandbyDeadline(); err != nil {
 		v.logger.Warnf("Failed to clear auto-standby deadline: %v", err)
 	}
+	// Clear the live deadline. The saved-for-hop-on copy is intentionally
+	// NOT touched here — handleHopOnRequest captured it before triggering
+	// EvHopOnEngage so EnterHopOn / EnterParked-from-HopOn can resume.
+	v.mu.Lock()
+	v.autoStandbyDeadline = time.Time{}
+	v.mu.Unlock()
 	return nil
 }
 
@@ -505,6 +547,149 @@ func (v *VehicleSystem) EnterHibernationConfirm(c *librefsm.Context) error {
 	return nil
 }
 
+// EnterHopOn enters hop-on / hop-off mode. The scooter stays powered up
+// but handleInputChange will publish-only every input. The auto-standby
+// timer is resumed from the deadline that handleHopOnRequest captured
+// just before sending EvHopOnEngage (since ExitParked already cleared
+// the live deadline by the time this runs).
+func (v *VehicleSystem) EnterHopOn(c *librefsm.Context) error {
+	v.logger.Infof("FSM: EnterHopOn")
+
+	// Resume the auto-standby timer using the saved deadline. If it has
+	// already passed, fire the timeout immediately so the FSM moves to
+	// shutdown without delay.
+	v.mu.RLock()
+	saved := v.hopOnSavedAutoStandbyDl
+	v.mu.RUnlock()
+
+	if !saved.IsZero() && v.machine != nil {
+		remaining := time.Until(saved)
+		if remaining < 1*time.Millisecond {
+			remaining = 1 * time.Millisecond
+		}
+		v.machine.StartTimer(fsm.TimerAutoStandby, remaining, librefsm.Event{ID: fsm.EvAutoStandbyTimeout})
+		v.mu.Lock()
+		v.autoStandbyDeadline = saved
+		v.mu.Unlock()
+		if err := v.redis.PublishAutoStandbyDeadline(saved); err != nil {
+			v.logger.Warnf("Failed to publish auto-standby deadline in hop-on: %v", err)
+		}
+		v.logger.Infof("hop-on: resumed auto-standby timer with %v remaining", remaining)
+	}
+
+	// Publish the hop-on flag so the dashboard renders the lock screen.
+	if err := v.redis.SetHopOnActive(true); err != nil {
+		v.logger.Warnf("Failed to publish hop-on-active=true: %v", err)
+	}
+
+	// Play the same LED cue we use for parked->standby (cue 7/8 picked
+	// by current brake state). Visually the scooter "powers down".
+	brakeLeft, brakeRight, _ := v.readBrakeStates()
+	if brakeLeft || brakeRight {
+		v.playLedCue(8, "hop-on engage (brakes on)")
+	} else {
+		v.playLedCue(7, "hop-on engage (brakes off)")
+	}
+
+	// Opportunistic steering-lock engagement: only if the handlebar
+	// happens to be in lock-position right now. Synchronous pulse
+	// (~1.1s) so run on a goroutine to avoid blocking the FSM.
+	positioned, err := v.io.ReadDigitalInputDirect("handlebar_position")
+	if err != nil {
+		v.logger.Warnf("hop-on: failed to read handlebar position: %v", err)
+	} else if positioned {
+		v.logger.Infof("hop-on: handlebar in position, engaging steering lock")
+		go func() {
+			if err := v.pulseHandlebarLock(true); err != nil {
+				v.logger.Warnf("hop-on: failed to pulse handlebar lock: %v", err)
+				return
+			}
+			time.Sleep(handlebarLockRetryDelay)
+			sensorVal, err := v.io.ReadDigitalInputDirect("handlebar_lock_sensor")
+			if err != nil {
+				v.logger.Warnf("hop-on: failed to read handlebar lock sensor after pulse: %v", err)
+				return
+			}
+			v.mu.Lock()
+			v.handlebarUnlocked = sensorVal
+			if !sensorVal {
+				v.hopOnLockedHandlebar = true
+			}
+			v.mu.Unlock()
+			if sensorVal {
+				v.logger.Warnf("hop-on: lock pulse fired but sensor still reads unlocked")
+			} else {
+				v.logger.Infof("hop-on: steering lock engaged")
+			}
+		}()
+	} else {
+		v.logger.Debugf("hop-on: handlebar not in position, skipping steering lock")
+	}
+
+	return nil
+}
+
+// ExitHopOn leaves hop-on / hop-off mode. Always cancels the auto-standby
+// timer (EnterParked or another state's onEnter will rearm it as needed),
+// publishes hop-on-active=false, plays the reverse LED cue, and releases
+// the steering lock if WE engaged it on entry.
+func (v *VehicleSystem) ExitHopOn(c *librefsm.Context) error {
+	v.logger.Infof("FSM: ExitHopOn")
+
+	if v.machine != nil {
+		v.machine.StopTimer(fsm.TimerAutoStandby)
+	}
+	if err := v.redis.ClearAutoStandbyDeadline(); err != nil {
+		v.logger.Warnf("Failed to clear auto-standby deadline on hop-on exit: %v", err)
+	}
+	v.mu.Lock()
+	v.autoStandbyDeadline = time.Time{}
+	v.mu.Unlock()
+
+	if err := v.redis.SetHopOnActive(false); err != nil {
+		v.logger.Warnf("Failed to publish hop-on-active=false: %v", err)
+	}
+
+	// Reverse LED cue: same one we play for standby->parked.
+	brakeLeft, brakeRight, _ := v.readBrakeStates()
+	if brakeLeft || brakeRight {
+		v.playLedCue(2, "hop-on release (brakes on)")
+	} else {
+		v.playLedCue(1, "hop-on release (brakes off)")
+	}
+
+	// Release the steering lock only if we engaged it on entry.
+	v.mu.Lock()
+	releaseHandlebar := v.hopOnLockedHandlebar
+	v.hopOnLockedHandlebar = false
+	v.mu.Unlock()
+	if releaseHandlebar {
+		v.logger.Infof("hop-on: releasing steering lock that we engaged")
+		go func() {
+			if err := v.pulseHandlebarLock(false); err != nil {
+				v.logger.Warnf("hop-on: failed to pulse handlebar unlock: %v", err)
+				return
+			}
+			time.Sleep(handlebarUnlockRetryDelay)
+			sensorVal, err := v.io.ReadDigitalInputDirect("handlebar_lock_sensor")
+			if err != nil {
+				v.logger.Warnf("hop-on: failed to read handlebar lock sensor after unlock pulse: %v", err)
+				return
+			}
+			v.mu.Lock()
+			v.handlebarUnlocked = sensorVal
+			v.mu.Unlock()
+			if !sensorVal {
+				v.logger.Warnf("hop-on: unlock pulse fired but sensor still reads locked")
+			} else {
+				v.logger.Infof("hop-on: steering lock released")
+			}
+		}()
+	}
+
+	return nil
+}
+
 // === Guards ===
 
 func (v *VehicleSystem) IsDashboardReady(c *librefsm.Context) bool {
@@ -560,16 +745,6 @@ func (v *VehicleSystem) AreBrakesPressed(c *librefsm.Context) bool {
 	brakeLeft, _ := v.io.ReadDigitalInput("brake_left")
 	brakeRight, _ := v.io.ReadDigitalInput("brake_right")
 	return brakeLeft && brakeRight
-}
-
-// IsHopOnInactive returns true while hop-on / hop-off mode is NOT engaged.
-// Used as an extra guard on every Parked->ReadyToDrive transition so that
-// while hop-on is active, neither EvUnlock, EvKickstandUp, EvDashboardReady
-// nor the seatbox+brakes manual RTD path can promote the FSM out of Parked.
-func (v *VehicleSystem) IsHopOnInactive(c *librefsm.Context) bool {
-	v.mu.RLock()
-	defer v.mu.RUnlock()
-	return !v.hopOnActive
 }
 
 // === Transition Actions ===

--- a/internal/core/fsm_actions.go
+++ b/internal/core/fsm_actions.go
@@ -562,6 +562,16 @@ func (v *VehicleSystem) AreBrakesPressed(c *librefsm.Context) bool {
 	return brakeLeft && brakeRight
 }
 
+// IsHopOnInactive returns true while hop-on / hop-off mode is NOT engaged.
+// Used as an extra guard on every Parked->ReadyToDrive transition so that
+// while hop-on is active, neither EvUnlock, EvKickstandUp, EvDashboardReady
+// nor the seatbox+brakes manual RTD path can promote the FSM out of Parked.
+func (v *VehicleSystem) IsHopOnInactive(c *librefsm.Context) bool {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	return !v.hopOnActive
+}
+
 // === Transition Actions ===
 
 func (v *VehicleSystem) OnShutdownTimeout(c *librefsm.Context) error {

--- a/internal/core/interfaces.go
+++ b/internal/core/interfaces.go
@@ -40,6 +40,9 @@ type MessagingClient interface {
 	PublishAutoStandbyDeadline(deadline time.Time) error
 	ClearAutoStandbyDeadline() error
 
+	// Hop-on / hop-off
+	SetHopOnActive(active bool) error
+
 	// Sensors and switches
 	SetBrakeState(side string, pressed bool) error
 	SetKickstandState(deployed bool) error

--- a/internal/core/redis_handlers.go
+++ b/internal/core/redis_handlers.go
@@ -408,6 +408,138 @@ func (v *VehicleSystem) handleHardwareRequest(command string) error {
 	return nil
 }
 
+// handleHopOnRequest engages or releases hop-on / hop-off mode.
+//
+// In hop-on mode the scooter stays in StateParked (auto-standby still ticks)
+// but the FSM blocks every Parked->ReadyToDrive transition via the
+// IsHopOnInactive guard, so a stranger kicking the kickstand up cannot ride
+// the scooter away. The dashboard turns its backlight off and watches for
+// the user-defined unlock combo.
+//
+// On engage, if the handlebar happens to be in lock-position right now, the
+// steering lock is engaged opportunistically (we do NOT wait for the user to
+// position it — that would defeat the "fast hop off" goal). On release the
+// lock is reversed only if WE engaged it.
+func (v *VehicleSystem) handleHopOnRequest(action string) error {
+	switch action {
+	case "engage":
+		v.mu.Lock()
+		if v.hopOnActive {
+			v.mu.Unlock()
+			v.logger.Debugf("hop-on engage requested but already active — no-op")
+			return nil
+		}
+		v.hopOnActive = true
+		v.mu.Unlock()
+
+		v.logger.Infof("Hop-on mode engaged")
+		if err := v.redis.SetHopOnActive(true); err != nil {
+			v.logger.Warnf("Failed to publish hop-on-active=true: %v", err)
+		}
+
+		// Play the same LED cue we use when transitioning Parked->Standby
+		// (cue 7 = brakes off, cue 8 = brakes on). Visually this turns the
+		// scooter "off" — same effect the user is used to from auto-lock.
+		brakeLeftHopOn, brakeRightHopOn, _ := v.readBrakeStates()
+		if brakeLeftHopOn || brakeRightHopOn {
+			v.playLedCue(8, "hop-on engage (brakes on)")
+		} else {
+			v.playLedCue(7, "hop-on engage (brakes off)")
+		}
+
+		// Opportunistic steering-lock engagement: only if the handlebar is
+		// already in position right now. The pulse is synchronous (~1.1s)
+		// so run it on a goroutine to avoid blocking the redis handler.
+		positioned, err := v.io.ReadDigitalInputDirect("handlebar_position")
+		if err != nil {
+			v.logger.Warnf("hop-on: failed to read handlebar position: %v", err)
+		} else if positioned {
+			v.logger.Infof("hop-on: handlebar in position, engaging steering lock")
+			go func() {
+				if err := v.pulseHandlebarLock(true); err != nil {
+					v.logger.Warnf("hop-on: failed to pulse handlebar lock: %v", err)
+					return
+				}
+				time.Sleep(handlebarLockRetryDelay)
+				sensorVal, err := v.io.ReadDigitalInputDirect("handlebar_lock_sensor")
+				if err != nil {
+					v.logger.Warnf("hop-on: failed to read handlebar lock sensor after pulse: %v", err)
+					return
+				}
+				v.mu.Lock()
+				v.handlebarUnlocked = sensorVal
+				if !sensorVal {
+					v.hopOnLockedHandlebar = true
+				}
+				v.mu.Unlock()
+				if sensorVal {
+					v.logger.Warnf("hop-on: lock pulse fired but sensor still reads unlocked")
+				} else {
+					v.logger.Infof("hop-on: steering lock engaged")
+				}
+			}()
+		} else {
+			v.logger.Debugf("hop-on: handlebar not in position, skipping steering lock")
+		}
+		return nil
+
+	case "release":
+		v.mu.Lock()
+		if !v.hopOnActive {
+			v.mu.Unlock()
+			v.logger.Debugf("hop-on release requested but not active — no-op")
+			return nil
+		}
+		v.hopOnActive = false
+		releaseHandlebar := v.hopOnLockedHandlebar
+		v.hopOnLockedHandlebar = false
+		v.mu.Unlock()
+
+		v.logger.Infof("Hop-on mode released")
+		if err := v.redis.SetHopOnActive(false); err != nil {
+			v.logger.Warnf("Failed to publish hop-on-active=false: %v", err)
+		}
+
+		// Play the same LED cue we use when transitioning Standby->Parked
+		// (cue 1 = brakes off, cue 2 = brakes on). Visually this turns the
+		// scooter back "on".
+		brakeLeftHopOff, brakeRightHopOff, _ := v.readBrakeStates()
+		if brakeLeftHopOff || brakeRightHopOff {
+			v.playLedCue(2, "hop-on release (brakes on)")
+		} else {
+			v.playLedCue(1, "hop-on release (brakes off)")
+		}
+
+		if releaseHandlebar {
+			v.logger.Infof("hop-on: releasing steering lock that we engaged")
+			go func() {
+				if err := v.pulseHandlebarLock(false); err != nil {
+					v.logger.Warnf("hop-on: failed to pulse handlebar unlock: %v", err)
+					return
+				}
+				time.Sleep(handlebarUnlockRetryDelay)
+				sensorVal, err := v.io.ReadDigitalInputDirect("handlebar_lock_sensor")
+				if err != nil {
+					v.logger.Warnf("hop-on: failed to read handlebar lock sensor after unlock pulse: %v", err)
+					return
+				}
+				v.mu.Lock()
+				v.handlebarUnlocked = sensorVal
+				v.mu.Unlock()
+				if !sensorVal {
+					v.logger.Warnf("hop-on: unlock pulse fired but sensor still reads locked")
+				} else {
+					v.logger.Infof("hop-on: steering lock released")
+				}
+			}()
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("invalid hop-on action: %s", action)
+	}
+}
+
 // handleSettingsUpdate processes settings changes from Redis
 func (v *VehicleSystem) handleSettingsUpdate(settingKey string) error {
 	v.logger.Infof("Handling settings update: %s", settingKey)

--- a/internal/core/redis_handlers.go
+++ b/internal/core/redis_handlers.go
@@ -408,132 +408,42 @@ func (v *VehicleSystem) handleHardwareRequest(command string) error {
 	return nil
 }
 
-// handleHopOnRequest engages or releases hop-on / hop-off mode.
-//
-// In hop-on mode the scooter stays in StateParked (auto-standby still ticks)
-// but the FSM blocks every Parked->ReadyToDrive transition via the
-// IsHopOnInactive guard, so a stranger kicking the kickstand up cannot ride
-// the scooter away. The dashboard turns its backlight off and watches for
-// the user-defined unlock combo.
-//
-// On engage, if the handlebar happens to be in lock-position right now, the
-// steering lock is engaged opportunistically (we do NOT wait for the user to
-// position it — that would defeat the "fast hop off" goal). On release the
-// lock is reversed only if WE engaged it.
+// handleHopOnRequest engages or releases hop-on / hop-off mode by
+// dispatching the corresponding FSM event. The actual side-effects (LED
+// cues, steering lock, vehicle:hop-on-active publishing, auto-standby
+// timer resume) live in EnterHopOn / ExitHopOn — this handler just
+// captures the live auto-standby deadline before the transition fires
+// (because ExitParked will clear it before EnterHopOn runs) and then
+// dispatches the event.
 func (v *VehicleSystem) handleHopOnRequest(action string) error {
+	if v.machine == nil {
+		return fmt.Errorf("hop-on: FSM not initialised")
+	}
 	switch action {
 	case "engage":
-		v.mu.Lock()
-		if v.hopOnActive {
-			v.mu.Unlock()
-			v.logger.Debugf("hop-on engage requested but already active — no-op")
+		current := v.machine.CurrentState()
+		if current == fsm.StateHopOn {
+			v.logger.Debugf("hop-on engage requested but already in StateHopOn — no-op")
 			return nil
 		}
-		v.hopOnActive = true
+		if current != fsm.StateParked {
+			v.logger.Warnf("hop-on engage refused: scooter is in %s, not parked", current)
+			return nil
+		}
+		// Capture the live auto-standby deadline so EnterHopOn (and later
+		// EnterParked from HopOn) can resume it. Without this the timer
+		// would restart from full duration on every hop-on cycle.
+		v.mu.Lock()
+		v.hopOnSavedAutoStandbyDl = v.autoStandbyDeadline
 		v.mu.Unlock()
-
-		v.logger.Infof("Hop-on mode engaged")
-		if err := v.redis.SetHopOnActive(true); err != nil {
-			v.logger.Warnf("Failed to publish hop-on-active=true: %v", err)
-		}
-
-		// Play the same LED cue we use when transitioning Parked->Standby
-		// (cue 7 = brakes off, cue 8 = brakes on). Visually this turns the
-		// scooter "off" — same effect the user is used to from auto-lock.
-		brakeLeftHopOn, brakeRightHopOn, _ := v.readBrakeStates()
-		if brakeLeftHopOn || brakeRightHopOn {
-			v.playLedCue(8, "hop-on engage (brakes on)")
-		} else {
-			v.playLedCue(7, "hop-on engage (brakes off)")
-		}
-
-		// Opportunistic steering-lock engagement: only if the handlebar is
-		// already in position right now. The pulse is synchronous (~1.1s)
-		// so run it on a goroutine to avoid blocking the redis handler.
-		positioned, err := v.io.ReadDigitalInputDirect("handlebar_position")
-		if err != nil {
-			v.logger.Warnf("hop-on: failed to read handlebar position: %v", err)
-		} else if positioned {
-			v.logger.Infof("hop-on: handlebar in position, engaging steering lock")
-			go func() {
-				if err := v.pulseHandlebarLock(true); err != nil {
-					v.logger.Warnf("hop-on: failed to pulse handlebar lock: %v", err)
-					return
-				}
-				time.Sleep(handlebarLockRetryDelay)
-				sensorVal, err := v.io.ReadDigitalInputDirect("handlebar_lock_sensor")
-				if err != nil {
-					v.logger.Warnf("hop-on: failed to read handlebar lock sensor after pulse: %v", err)
-					return
-				}
-				v.mu.Lock()
-				v.handlebarUnlocked = sensorVal
-				if !sensorVal {
-					v.hopOnLockedHandlebar = true
-				}
-				v.mu.Unlock()
-				if sensorVal {
-					v.logger.Warnf("hop-on: lock pulse fired but sensor still reads unlocked")
-				} else {
-					v.logger.Infof("hop-on: steering lock engaged")
-				}
-			}()
-		} else {
-			v.logger.Debugf("hop-on: handlebar not in position, skipping steering lock")
-		}
-		return nil
+		return v.machine.SendSync(librefsm.Event{ID: fsm.EvHopOnEngage})
 
 	case "release":
-		v.mu.Lock()
-		if !v.hopOnActive {
-			v.mu.Unlock()
-			v.logger.Debugf("hop-on release requested but not active — no-op")
+		if v.machine.CurrentState() != fsm.StateHopOn {
+			v.logger.Debugf("hop-on release requested but not in StateHopOn — no-op")
 			return nil
 		}
-		v.hopOnActive = false
-		releaseHandlebar := v.hopOnLockedHandlebar
-		v.hopOnLockedHandlebar = false
-		v.mu.Unlock()
-
-		v.logger.Infof("Hop-on mode released")
-		if err := v.redis.SetHopOnActive(false); err != nil {
-			v.logger.Warnf("Failed to publish hop-on-active=false: %v", err)
-		}
-
-		// Play the same LED cue we use when transitioning Standby->Parked
-		// (cue 1 = brakes off, cue 2 = brakes on). Visually this turns the
-		// scooter back "on".
-		brakeLeftHopOff, brakeRightHopOff, _ := v.readBrakeStates()
-		if brakeLeftHopOff || brakeRightHopOff {
-			v.playLedCue(2, "hop-on release (brakes on)")
-		} else {
-			v.playLedCue(1, "hop-on release (brakes off)")
-		}
-
-		if releaseHandlebar {
-			v.logger.Infof("hop-on: releasing steering lock that we engaged")
-			go func() {
-				if err := v.pulseHandlebarLock(false); err != nil {
-					v.logger.Warnf("hop-on: failed to pulse handlebar unlock: %v", err)
-					return
-				}
-				time.Sleep(handlebarUnlockRetryDelay)
-				sensorVal, err := v.io.ReadDigitalInputDirect("handlebar_lock_sensor")
-				if err != nil {
-					v.logger.Warnf("hop-on: failed to read handlebar lock sensor after unlock pulse: %v", err)
-					return
-				}
-				v.mu.Lock()
-				v.handlebarUnlocked = sensorVal
-				v.mu.Unlock()
-				if !sensorVal {
-					v.logger.Warnf("hop-on: unlock pulse fired but sensor still reads locked")
-				} else {
-					v.logger.Infof("hop-on: steering lock released")
-				}
-			}()
-		}
-		return nil
+		return v.machine.SendSync(librefsm.Event{ID: fsm.EvHopOnRelease})
 
 	default:
 		return fmt.Errorf("invalid hop-on action: %s", action)

--- a/internal/core/system.go
+++ b/internal/core/system.go
@@ -82,6 +82,10 @@ type VehicleSystem struct {
 	hornEnableMode          string            // Horn enable mode: "true", "false", or "in-drive" (default: "true")
 	hibernationForceTimer   *time.Timer       // Timer for forcing hibernation after 15s of brake hold
 	machine                 *librefsm.Machine // librefsm state machine
+
+	// Hop-on / hop-off mode (runtime-only — does NOT survive a power cycle)
+	hopOnActive          bool // While true, FSM blocks Parked->ReadyToDrive
+	hopOnLockedHandlebar bool // True when WE engaged the steering lock on hop-on entry
 }
 
 func NewVehicleSystem(io HardwareIO, redis MessagingClient, l *logger.Logger) *VehicleSystem {
@@ -125,6 +129,7 @@ func (v *VehicleSystem) Start() error {
 		HardwareCallback:  v.handleHardwareRequest,
 		SettingsCallback:        v.handleSettingsUpdate,
 		OtaDbcActivityCallback: v.resetDbcWatchdog,
+		HopOnCallback:          v.handleHopOnRequest,
 	})
 
 	// Connect to Redis first so we can retrieve saved state

--- a/internal/core/system.go
+++ b/internal/core/system.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -83,9 +84,12 @@ type VehicleSystem struct {
 	hibernationForceTimer   *time.Timer       // Timer for forcing hibernation after 15s of brake hold
 	machine                 *librefsm.Machine // librefsm state machine
 
-	// Hop-on / hop-off mode (runtime-only — does NOT survive a power cycle)
-	hopOnActive          bool // While true, FSM blocks Parked->ReadyToDrive
-	hopOnLockedHandlebar bool // True when WE engaged the steering lock on hop-on entry
+	// Hop-on / hop-off mode (runtime-only — does NOT survive a power cycle).
+	// State is implicit in the FSM (StateHopOn). The two fields below are
+	// transient bookkeeping carried across the engage/release transitions.
+	hopOnLockedHandlebar    bool      // True when WE engaged the steering lock on hop-on entry
+	autoStandbyDeadline     time.Time // Live auto-standby deadline (set by EnterParked / EnterHopOn)
+	hopOnSavedAutoStandbyDl time.Time // Captured by handleHopOnRequest before ExitParked clears the live one
 }
 
 func NewVehicleSystem(io HardwareIO, redis MessagingClient, l *logger.Logger) *VehicleSystem {
@@ -669,6 +673,50 @@ func (v *VehicleSystem) handleInputChange(channel string, value bool) error {
 			v.logger.Infof("Warning: Failed to publish button event: %v", err)
 			// Continue with normal processing even if PUBSUB fails
 		}
+	}
+
+	// Hop-on / hop-off mode: publish input state but skip ALL action
+	// processing. The dashboard uses these inputs to match the unlock
+	// combo via the buttons PUBSUB channel and the vehicle hash sync;
+	// the scooter must NOT honk, blink, open the seatbox, or transition
+	// out of HopOn except via an explicit hop-on release (or one of the
+	// standard escape transitions defined on StateHopOn: lock, force-lock,
+	// keycard, auto-standby timeout). FSM events are deliberately not
+	// sent here so the FSM never sees kickstand-up etc. while in HopOn.
+	if v.machine != nil && v.machine.CurrentState() == fsm.StateHopOn {
+		switch channel {
+		case "brake_left":
+			return v.redis.SetBrakeState("left", value)
+		case "brake_right":
+			return v.redis.SetBrakeState("right", value)
+		case "horn_button":
+			return v.redis.SetHornButton(value)
+		case "seatbox_button":
+			return v.redis.SetSeatboxButton(value)
+		case "kickstand":
+			return v.redis.SetKickstandState(value)
+		case "blinker_left", "blinker_right":
+			// The top of this function skipped the PUBSUB publish for
+			// blinker channels (handleBlinkerChange normally handles them)
+			// — emit it manually so the dashboard's matcher sees it.
+			position := strings.TrimPrefix(channel, "blinker_")
+			evt := fmt.Sprintf("blinker:%s:%s", position, state)
+			if err := v.redis.PublishButtonEvent(evt); err != nil {
+				v.logger.Warnf("hop-on: failed to publish %s: %v", evt, err)
+			}
+			switchState := "off"
+			if value {
+				switchState = position
+			}
+			return v.redis.SetBlinkerSwitch(switchState)
+		case "handlebar_lock_sensor":
+			isLocked := !value
+			v.mu.Lock()
+			v.handlebarUnlocked = value // sensor true = unlocked
+			v.mu.Unlock()
+			return v.redis.SetHandlebarLockState(isLocked)
+		}
+		return nil
 	}
 
 	// First check if we should handle this input in current state

--- a/internal/core/system_test.go
+++ b/internal/core/system_test.go
@@ -59,6 +59,7 @@ func (m *mockMessagingClient) RemoveInhibitor(id string) error                { 
 func (m *mockMessagingClient) GetHashField(hash, field string) (string, error) { return m.hashFieldValue, nil }
 func (m *mockMessagingClient) PublishAutoStandbyDeadline(deadline time.Time) error { return nil }
 func (m *mockMessagingClient) ClearAutoStandbyDeadline() error                { return nil }
+func (m *mockMessagingClient) SetHopOnActive(active bool) error               { return nil }
 func (m *mockMessagingClient) SetKickstandState(deployed bool) error          { return nil }
 func (m *mockMessagingClient) SetHandlebarLockState(locked bool) error        { return nil }
 func (m *mockMessagingClient) SetSeatboxLockState(locked bool) error          { return nil }

--- a/internal/fsm/actions.go
+++ b/internal/fsm/actions.go
@@ -32,6 +32,7 @@ type Actions interface {
 	IsSeatboxClosed(c *librefsm.Context) bool
 	AreBrakesPressed(c *librefsm.Context) bool
 	IsHandlebarUnlocked(c *librefsm.Context) bool // True when handlebar lock sensor shows unlocked
+	IsHopOnInactive(c *librefsm.Context) bool     // False while hop-on / hop-off mode is engaged (blocks Parked->RTD)
 
 	// Transition actions
 	OnShutdownTimeout(c *librefsm.Context) error

--- a/internal/fsm/actions.go
+++ b/internal/fsm/actions.go
@@ -24,6 +24,10 @@ type Actions interface {
 	EnterHibernationSeatbox(c *librefsm.Context) error
 	EnterHibernationConfirm(c *librefsm.Context) error
 
+	// Hop-on / hop-off state actions
+	EnterHopOn(c *librefsm.Context) error
+	ExitHopOn(c *librefsm.Context) error
+
 	// Guards for conditional transitions
 	CanEnterReadyToDrive(c *librefsm.Context) bool // True when both kickstand up AND dashboard ready
 	IsDashboardReady(c *librefsm.Context) bool     // True when dashboard has booted
@@ -32,7 +36,6 @@ type Actions interface {
 	IsSeatboxClosed(c *librefsm.Context) bool
 	AreBrakesPressed(c *librefsm.Context) bool
 	IsHandlebarUnlocked(c *librefsm.Context) bool // True when handlebar lock sensor shows unlocked
-	IsHopOnInactive(c *librefsm.Context) bool     // False while hop-on / hop-off mode is engaged (blocks Parked->RTD)
 
 	// Transition actions
 	OnShutdownTimeout(c *librefsm.Context) error

--- a/internal/fsm/definition.go
+++ b/internal/fsm/definition.go
@@ -83,15 +83,17 @@ func NewDefinition(actions Actions) *librefsm.Definition {
 		Transition(StateStandby, EvKeycardAuth, StateParked).    // Keycard tap unlocks from standby
 		Transition(StateStandby, EvDbcUpdateComplete, StateShuttingDown). // DBC update complete, give DBC time to poweroff
 
-		// From Parked - unlock/kickstand-up/dashboard-ready to ReadyToDrive if conditions met
+		// From Parked - unlock/kickstand-up/dashboard-ready to ReadyToDrive if conditions met.
+		// IsHopOnInactive blocks every promotion to RTD while hop-on / hop-off mode is engaged,
+		// so a stranger kicking the kickstand up cannot ride the scooter away.
 		Transition(StateParked, EvUnlock, StateReadyToDrive,
-			librefsm.WithGuard(actions.CanEnterReadyToDrive), // Requires both kickstand up AND dashboard ready
+			librefsm.WithGuards(actions.CanEnterReadyToDrive, actions.IsHopOnInactive),
 		).
 		Transition(StateParked, EvKickstandUp, StateReadyToDrive,
-			librefsm.WithGuards(actions.IsDashboardReady, actions.IsHandlebarUnlocked),
+			librefsm.WithGuards(actions.IsDashboardReady, actions.IsHandlebarUnlocked, actions.IsHopOnInactive),
 		).
 		Transition(StateParked, EvDashboardReady, StateReadyToDrive,
-			librefsm.WithGuards(actions.IsKickstandUp, actions.IsHandlebarUnlocked),
+			librefsm.WithGuards(actions.IsKickstandUp, actions.IsHandlebarUnlocked, actions.IsHopOnInactive),
 		).
 		Transition(StateParked, EvLock, StateShuttingDown,
 			librefsm.WithGuard(actions.IsSeatboxClosed),
@@ -110,9 +112,10 @@ func NewDefinition(actions Actions) *librefsm.Definition {
 			librefsm.WithGuard(actions.IsKickstandDown), // Seatbox open, kickstand down
 		).
 		Transition(StateParked, EvAutoStandbyTimeout, StateShuttingDown).
-		// Manual ready-to-drive: seatbox button with kickstand up and both brakes pressed
+		// Manual ready-to-drive: seatbox button with kickstand up and both brakes pressed.
+		// IsHopOnInactive ensures the manual override is also blocked during hop-on.
 		Transition(StateParked, EvSeatboxButton, StateReadyToDrive,
-			librefsm.WithGuards(actions.IsKickstandUp, actions.AreBrakesPressed),
+			librefsm.WithGuards(actions.IsKickstandUp, actions.AreBrakesPressed, actions.IsHopOnInactive),
 		).
 		// Normal seatbox opening: button pressed in parked with kickstand down
 		Transition(StateParked, EvSeatboxButton, StateParked,

--- a/internal/fsm/definition.go
+++ b/internal/fsm/definition.go
@@ -73,6 +73,17 @@ func NewDefinition(actions Actions) *librefsm.Definition {
 			librefsm.WithOnEnter(actions.EnterHibernationConfirm),
 		).
 
+		// Hop-on / hop-off mode (sibling of Parked).
+		// While in this state every physical input is published only,
+		// never processed — see handleInputChange's hop-on early-return.
+		// The auto-standby deadline is preserved across the engage and
+		// release transitions by VehicleSystem so a forgotten hop-on
+		// still drops to standby on the original schedule.
+		State(StateHopOn,
+			librefsm.WithOnEnter(actions.EnterHopOn),
+			librefsm.WithOnExit(actions.ExitHopOn),
+		).
+
 		// === Transitions ===
 
 		// From Init
@@ -84,16 +95,14 @@ func NewDefinition(actions Actions) *librefsm.Definition {
 		Transition(StateStandby, EvDbcUpdateComplete, StateShuttingDown). // DBC update complete, give DBC time to poweroff
 
 		// From Parked - unlock/kickstand-up/dashboard-ready to ReadyToDrive if conditions met.
-		// IsHopOnInactive blocks every promotion to RTD while hop-on / hop-off mode is engaged,
-		// so a stranger kicking the kickstand up cannot ride the scooter away.
 		Transition(StateParked, EvUnlock, StateReadyToDrive,
-			librefsm.WithGuards(actions.CanEnterReadyToDrive, actions.IsHopOnInactive),
+			librefsm.WithGuard(actions.CanEnterReadyToDrive), // Requires both kickstand up AND dashboard ready
 		).
 		Transition(StateParked, EvKickstandUp, StateReadyToDrive,
-			librefsm.WithGuards(actions.IsDashboardReady, actions.IsHandlebarUnlocked, actions.IsHopOnInactive),
+			librefsm.WithGuards(actions.IsDashboardReady, actions.IsHandlebarUnlocked),
 		).
 		Transition(StateParked, EvDashboardReady, StateReadyToDrive,
-			librefsm.WithGuards(actions.IsKickstandUp, actions.IsHandlebarUnlocked, actions.IsHopOnInactive),
+			librefsm.WithGuards(actions.IsKickstandUp, actions.IsHandlebarUnlocked),
 		).
 		Transition(StateParked, EvLock, StateShuttingDown,
 			librefsm.WithGuard(actions.IsSeatboxClosed),
@@ -112,10 +121,9 @@ func NewDefinition(actions Actions) *librefsm.Definition {
 			librefsm.WithGuard(actions.IsKickstandDown), // Seatbox open, kickstand down
 		).
 		Transition(StateParked, EvAutoStandbyTimeout, StateShuttingDown).
-		// Manual ready-to-drive: seatbox button with kickstand up and both brakes pressed.
-		// IsHopOnInactive ensures the manual override is also blocked during hop-on.
+		// Manual ready-to-drive: seatbox button with kickstand up and both brakes pressed
 		Transition(StateParked, EvSeatboxButton, StateReadyToDrive,
-			librefsm.WithGuards(actions.IsKickstandUp, actions.AreBrakesPressed, actions.IsHopOnInactive),
+			librefsm.WithGuards(actions.IsKickstandUp, actions.AreBrakesPressed),
 		).
 		// Normal seatbox opening: button pressed in parked with kickstand down
 		Transition(StateParked, EvSeatboxButton, StateParked,
@@ -125,6 +133,30 @@ func NewDefinition(actions Actions) *librefsm.Definition {
 		// Hibernation entry: both brakes pressed in parked state
 		Transition(StateParked, EvBrakesPressed, StateHibernationInitialHold,
 			librefsm.WithGuard(actions.AreBrakesPressed),
+		).
+		// Hop-on / hop-off engage
+		Transition(StateParked, EvHopOnEngage, StateHopOn).
+
+		// From HopOn — the only "normal" exit is the explicit release
+		// (combo matched on the dashboard). Standard escape paths still
+		// work: lock, force-lock, keycard, auto-standby timeout. Inputs
+		// like kickstand-up are deliberately NOT routed here because
+		// handleInputChange suppresses every FSM event send while in
+		// StateHopOn — the inputs are published but not processed.
+		Transition(StateHopOn, EvHopOnRelease, StateParked).
+		Transition(StateHopOn, EvAutoStandbyTimeout, StateShuttingDown).
+		Transition(StateHopOn, EvLock, StateShuttingDown,
+			librefsm.WithGuard(actions.IsSeatboxClosed),
+		).
+		Transition(StateHopOn, EvLock, StateWaitingSeatbox). // Fallback if seatbox open
+		Transition(StateHopOn, EvForceLock, StateStandby,
+			librefsm.WithAction(actions.OnForceLock),
+		).
+		Transition(StateHopOn, EvKeycardAuth, StateShuttingDown,
+			librefsm.WithGuards(actions.IsKickstandDown, actions.IsSeatboxClosed),
+		).
+		Transition(StateHopOn, EvKeycardAuth, StateWaitingSeatbox,
+			librefsm.WithGuard(actions.IsKickstandDown),
 		).
 
 		// From ReadyToDrive

--- a/internal/fsm/states.go
+++ b/internal/fsm/states.go
@@ -18,6 +18,14 @@ const (
 	StateHibernationAwaitingConfirm librefsm.StateID = "hibernation-awaiting-confirm"
 	StateHibernationSeatbox         librefsm.StateID = "hibernation-seatbox"
 	StateHibernationConfirm         librefsm.StateID = "hibernation-confirm"
+
+	// Hop-on / hop-off mode: a sibling of Parked. While in this state the
+	// scooter stays powered up but ALL physical inputs are published only,
+	// never processed (no horn, no blinker, no kickstand->RTD, no seatbox
+	// open). The auto-standby timer's deadline is preserved across the
+	// engage/release transitions so a forgotten hop-on still drops to
+	// standby on schedule.
+	StateHopOn librefsm.StateID = "hop-on"
 )
 
 // Vehicle events
@@ -53,6 +61,10 @@ const (
 
 	// Seatbox events
 	EvSeatboxClosed librefsm.EventID = "seatbox-closed"
+
+	// Hop-on / hop-off mode events
+	EvHopOnEngage  librefsm.EventID = "hop-on-engage"
+	EvHopOnRelease librefsm.EventID = "hop-on-release"
 )
 
 // Timer names for imperative timers

--- a/internal/messaging/redis.go
+++ b/internal/messaging/redis.go
@@ -28,6 +28,7 @@ type Callbacks struct {
 	HardwareCallback  func(string) error // "dashboard:on", "dashboard:off", "engine:on", "engine:off", "handlebar:lock", "handlebar:unlock"
 	SettingsCallback  func(string) error // setting key that was updated (e.g., "scooter.brake-hibernation")
 	OtaDbcActivityCallback func() error  // Called on any OTA hash field change for DBC component
+	HopOnCallback     func(string) error // "engage", "release"
 }
 
 type RedisClient struct {
@@ -166,6 +167,7 @@ func (r *RedisClient) StartListening() error {
 	ipc.HandleRequests(r.client, "scooter:led:fade", r.handleLedFadeCommand)
 	ipc.HandleRequests(r.client, "scooter:update", r.handleUpdateCommand)
 	ipc.HandleRequests(r.client, "scooter:hardware", r.handleHardwareCommand)
+	ipc.HandleRequests(r.client, "scooter:hop-on", r.handleHopOnCommand)
 
 	r.logger.Infof("Successfully started all Redis listeners")
 	return nil
@@ -279,6 +281,24 @@ func (r *RedisClient) handleHardwareCommand(value string) error {
 	r.logger.Infof("Processing hardware command: %s", value)
 
 	return r.callbacks.HardwareCallback(value)
+}
+
+// handleHopOnCommand processes hop-on / hop-off mode commands.
+// Accepts "engage" to enter hop-on mode (block ready-to-drive transitions)
+// and "release" to leave it. The dashboard sends these via LPUSH to
+// "scooter:hop-on".
+func (r *RedisClient) handleHopOnCommand(value string) error {
+	if r.callbacks.HopOnCallback == nil {
+		return nil
+	}
+	switch value {
+	case "engage", "release":
+		r.logger.Infof("Processing hop-on command: %s", value)
+		return r.callbacks.HopOnCallback(value)
+	default:
+		r.logger.Infof("Invalid hop-on command value: %s", value)
+		return fmt.Errorf("invalid hop-on command: %s", value)
+	}
 }
 
 
@@ -534,6 +554,22 @@ func (r *RedisClient) GetDashboardPower() (bool, error) {
 		return false, nil // Field doesn't exist, default to false/off
 	}
 	return value == "on", nil
+}
+
+// SetHopOnActive publishes the hop-on / hop-off mode flag to the vehicle hash.
+// While true, the FSM blocks Parked->ReadyToDrive transitions so the scooter
+// stays powered up but cannot be ridden away.
+func (r *RedisClient) SetHopOnActive(active bool) error {
+	value := "false"
+	if active {
+		value = "true"
+	}
+	if err := r.vehiclePub.Set("hop-on-active", value); err != nil {
+		r.logger.Warnf("Failed to set hop-on-active: %v", err)
+		return err
+	}
+	r.logger.Infof("Set hop-on-active=%s", value)
+	return nil
 }
 
 // PublishUpdateStatus publishes the update status to Redis


### PR DESCRIPTION
Adds a runtime-only lockout mode that keeps the scooter in StateParked (so the auto-standby timer keeps ticking) but blocks every Parked -> ReadyToDrive transition, so a stranger kicking the kickstand up cannot ride it away.

The dashboard engages the mode by pushing "engage" to the new scooter:hop-on Redis command queue and clears it with "release". A new IsHopOnInactive guard is added to all four Parked->RTD transitions (EvUnlock, EvKickstandUp, EvDashboardReady, and the seatbox+brakes manual override). Other escapes (EvLock, EvForceLock, EvKeycardAuth, EvAutoStandbyTimeout) remain unguarded so the scooter can still drop to standby normally.

On engage, if the handlebar position sensor reads on-place right now, the steering lock is engaged opportunistically (no waiting). On release the lock is reversed only if we engaged it ourselves.

The same LED cues used for parked<->standby transitions (cue 7/8 on engage, cue 1/2 on release, picked by current brake state) play during the mode flip so the scooter visually "powers down" and back up the way the user already expects from the auto-lock countdown.

Hop-on state is intentionally not persisted across reboots: a power cycle should never leave the scooter mysteriously locked out.