### PR TITLE
refactor(fsm): hoist kickstand-up RTD transition to hibernation parent

### DIFF
--- a/internal/fsm/definition.go
+++ b/internal/fsm/definition.go
@@ -192,14 +192,6 @@ func NewDefinition(actions Actions) *librefsm.Definition {
 		Transition(StateHibernationInitialHold, EvSeatboxButton, StateReadyToDrive,
 			librefsm.WithGuards(actions.IsKickstandUp, actions.AreBrakesPressed),
 		).
-		// Raising the kickstand while the brake-hold timer is counting down
-		// means the rider wants to drive, not hibernate. Route straight to
-		// RTD — otherwise the parent's EvKickstandUp->Parked fallback wins
-		// and the (already-raised) kickstand never produces a fresh edge to
-		// re-trigger the Parked->RTD transition.
-		Transition(StateHibernationInitialHold, EvKickstandUp, StateReadyToDrive,
-			librefsm.WithGuards(actions.IsDashboardReady, actions.IsHandlebarUnlocked),
-		).
 		// Initial hold -> either advance (timeout) or cancel (brakes released)
 		Transition(StateHibernationInitialHold, EvHibernationInitialTimeout, StateHibernationAwaitingConfirm).
 		Transition(StateHibernationInitialHold, EvBrakesReleased, StateParked).
@@ -226,6 +218,14 @@ func NewDefinition(actions Actions) *librefsm.Definition {
 		// Global transitions from any hibernation state (via parent)
 		// Physical events that cancel hibernation from any substate
 		Transition(StateHibernation, EvUnlock, StateParked).
+		// Raising the kickstand cancels hibernation. If the rider is also
+		// ready to drive (dashboard up, handlebar unlocked) skip the Parked
+		// hop and go straight to RTD — otherwise the parent fallback to
+		// Parked would land us in a state where the (already-raised)
+		// kickstand can never produce a fresh edge to fire Parked->RTD.
+		Transition(StateHibernation, EvKickstandUp, StateReadyToDrive,
+			librefsm.WithGuards(actions.IsDashboardReady, actions.IsHandlebarUnlocked),
+		).
 		Transition(StateHibernation, EvKickstandUp, StateParked).
 
 		// Initial state


### PR DESCRIPTION
## Summary

Follow-up to 6027eb1. That commit fixed a stuck-FSM bug in `HibernationInitialHold` by adding a substate-specific `EvKickstandUp -> ReadyToDrive` transition that bypassed the parent's `EvKickstandUp -> Parked` fallback. The fallback leaves the rider stuck when the kickstand is already up: no fresh edge fires `Parked -> RTD`.

The same edge-exhaustion latently affects every other hibernation substate (`HibernationAwaitingConfirm`, `HibernationSeatbox`, `HibernationConfirm`). Less commonly hit, same root cause.

This PR hoists the guarded transition to the `Hibernation` parent and drops the substate copy. One rule for the whole hibernation subtree: kickstand-up tries to drive (guards: dashboard ready, handlebar unlocked); failing the guards falls through to the existing `Hibernation -> Parked`.

## Behavior change

For substates other than `InitialHold`, raising the kickstand previously cancelled to `Parked`. With this PR it routes straight to `RTD` when guards pass. This matches rider intent (kickstand up = ride) and matches what `Parked` already does on the same input. Safety guards are unchanged.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [ ] On Deep-Blue: brake-hold to enter `HibernationInitialHold`, raise kickstand → expect `ReadyToDrive`
- [ ] On Deep-Blue: brake-hold past initial timeout to `HibernationAwaitingConfirm`, raise kickstand → expect `ReadyToDrive` (was `Parked`)
- [ ] On Deep-Blue: with handlebar locked, raise kickstand from any hibernation substate → expect `Parked` (fallback)