### PR TITLE
feat(usb0): gate auto policy on keycard pairing threshold

### DIFF
--- a/internal/core/redis_handlers.go
+++ b/internal/core/redis_handlers.go
@@ -578,10 +578,11 @@ func (v *VehicleSystem) handleSettingsUpdate(settingKey string) error {
 		v.mu.Lock()
 		v.usb0Policy = policy
 		v.mu.Unlock()
-		v.logger.Infof("usb0 policy updated to: %s", policy)
+		effective := v.usb0AutoEffective()
+		v.logger.Infof("usb0 policy updated to: %s (auto-effective=%v)", policy, effective)
 		// Apply immediately so the link reflects the new policy without
 		// waiting for the next dashboard transition.
-		if policy == "auto" {
+		if effective {
 			dashboardPower, dpErr := v.redis.GetDashboardPower()
 			if dpErr != nil {
 				v.logger.Warnf("Failed to read dashboard power while applying usb0=auto: %v", dpErr)

--- a/internal/core/system.go
+++ b/internal/core/system.go
@@ -385,8 +385,9 @@ func (v *VehicleSystem) Start() error {
 	v.mu.RLock()
 	policy := v.usb0Policy
 	v.mu.RUnlock()
-	v.logger.Infof("usb0 policy=%s", policy)
-	if policy != "auto" {
+	effective := v.usb0AutoEffective()
+	v.logger.Infof("usb0 policy=%s, auto-effective=%v", policy, effective)
+	if !effective {
 		if err := v.io.SetUsb0Enabled(true); err != nil {
 			v.logger.Warnf("Failed to bring usb0 up at startup: %v", err)
 		}
@@ -1324,19 +1325,17 @@ func (v *VehicleSystem) setPower(component string, enabled bool) error {
 			v.logger.Warnf("Failed to persist dashboard power state to Redis: %v", err)
 			// Don't return error - hardware state was set successfully
 		}
-		v.mu.RLock()
-		policy := v.usb0Policy
-		v.mu.RUnlock()
-		if policy == "auto" {
+		if v.usb0AutoEffective() {
 			if err := v.io.SetUsb0Enabled(enabled); err != nil {
 				v.logger.Warnf("Failed to set usb0 link: %v", err)
 				// Don't return error - dashboard power state was set successfully
 			}
 		} else {
-			// always-on: keep usb0 up regardless of dashboard_power so
-			// installer/diag tools retain reachability. Reassert here so a
-			// transient interface bounce gets corrected on the next state
-			// transition.
+			// Keep usb0 up regardless of dashboard_power: either the user
+			// picked always-on, or auto is gated by insufficient keycard
+			// pairings. Either way installer/diag tools need reachability.
+			// Reassert so a transient bounce gets corrected on the next
+			// state transition.
 			if err := v.io.SetUsb0Enabled(true); err != nil {
 				v.logger.Warnf("Failed to reassert usb0 always-on: %v", err)
 			}
@@ -1509,6 +1508,47 @@ func (v *VehicleSystem) stopDbcWatchdog() {
 		v.dbcWatchdogTimer.Stop()
 		v.dbcWatchdogTimer = nil
 	}
+}
+
+// usb0AutoEffective reports whether the usb0=auto policy should actually
+// take effect right now. Even when the user has opted in to auto, we keep
+// usb0 up until enough keycards are paired to recover from a lockout —
+// otherwise a bad pairing could leave the scooter unreachable to both the
+// owner (no working card) and the installer (no usb0).
+//
+// Threshold: (master >= 1 AND authorized >= 1) OR authorized >= 2.
+// Counts are published to the "system" hash by keycard-service.
+func (v *VehicleSystem) usb0AutoEffective() bool {
+	v.mu.RLock()
+	policy := v.usb0Policy
+	v.mu.RUnlock()
+	if policy != "auto" {
+		return false
+	}
+
+	master := v.readKeycardCount("keycard-master-count")
+	authorized := v.readKeycardCount("keycard-authorized-count")
+
+	if master >= 1 && authorized >= 1 {
+		return true
+	}
+	if authorized >= 2 {
+		return true
+	}
+	return false
+}
+
+func (v *VehicleSystem) readKeycardCount(field string) int {
+	raw, err := v.redis.GetHashField("system", field)
+	if err != nil || raw == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		v.logger.Warnf("Bad %s in system hash: %q (%v)", field, raw, err)
+		return 0
+	}
+	return n
 }
 
 func (v *VehicleSystem) Shutdown() {


### PR DESCRIPTION
Gates the existing `scooter.usb0-policy=auto` behavior on a keycard pairing threshold:

```
(master >= 1 AND authorized >= 1) OR authorized >= 2
```

Below threshold, callers fall back to `always-on`. Counts come from the `system` hash (populated by [librescoot/keycard-service#5](https://github.com/librescoot/keycard-service/pull/5)).

Evaluated live at the three existing decision points (boot, dashboard_power change, policy change). Counts are not subscribed to — threshold flips take effect at the next decision event.

## Test plan
- [x] Boot with policy=auto and threshold met: log reports `auto-effective=true`, usb0 follows `dashboard_power`
- [x] Zero counts and re-trigger handler: `auto-effective=false`, usb0 forced up
- [x] Restore counts and re-trigger handler: `auto-effective=true`, usb0 follows `dashboard_power` again