### PR TITLE
fix(fsm): only force-lock can leave ready-to-drive

### DIFF
--- a/internal/core/redis_handlers.go
+++ b/internal/core/redis_handlers.go
@@ -126,8 +126,8 @@ func (v *VehicleSystem) handleStateRequest(state string) error {
 		return v.machine.SendSync(librefsm.Event{ID: fsm.EvUnlock})
 
 	case "lock":
-		if currentState != types.StateParked && currentState != types.StateReadyToDrive {
-			return fmt.Errorf("vehicle must be parked or ready-to-drive to lock")
+		if currentState != types.StateParked {
+			return fmt.Errorf("vehicle must be parked to lock (use force-lock from drive)")
 		}
 		v.logger.Infof("Sending EvLock")
 		return v.machine.SendSync(librefsm.Event{ID: fsm.EvLock})

--- a/internal/core/system.go
+++ b/internal/core/system.go
@@ -1237,6 +1237,10 @@ func (v *VehicleSystem) keycardAuthPassed() error {
 	v.logger.Infof("Processing keycard authentication tap")
 
 	// --- Force Standby Check (3 taps + brake) ---
+	// Works from any state, including ready-to-drive. A single tap or a
+	// regular `lock` Redis command cannot shut down from drive; only this
+	// triple-tap-with-brake gesture (or the explicit force-lock Redis
+	// command) routes through EvForceLock.
 	brakeLeft, errL := v.io.ReadDigitalInput("brake_left")
 	if errL != nil {
 		v.logger.Debugf("Warning: Failed to read brake_left for keycard auth, assuming not pressed: %v", errL)

--- a/internal/core/system_test.go
+++ b/internal/core/system_test.go
@@ -1690,3 +1690,104 @@ func TestHopOn_RestoreFromSavedState(t *testing.T) {
 		t.Errorf("auto-standby timer should be armed after restoring into the at-rest group")
 	}
 }
+
+// rtdLockTestSetup brings a fresh VehicleSystem up in ready-to-drive with the
+// hardware inputs that match: kickstand up, no brakes, dashboard ready,
+// seatbox closed.
+func rtdLockTestSetup(t *testing.T) (*VehicleSystem, *mockHardwareIO) {
+	t.Helper()
+	system, mockIO, _ := newTestVehicleSystem()
+
+	mockIO.digitalInputs["kickstand"] = false // up
+	mockIO.digitalInputs["brake_left"] = false
+	mockIO.digitalInputs["brake_right"] = false
+	mockIO.digitalInputs["handlebar_position"] = false
+	mockIO.digitalInputs["handlebar_lock_sensor"] = false // unlocked
+	mockIO.digitalInputs["seatbox_lock_sensor"] = true
+
+	initTestFSM(t, system)
+
+	if err := system.machine.SetState(fsm.StateReadyToDrive); err != nil {
+		t.Fatalf("SetState ReadyToDrive: %v", err)
+	}
+	system.initialized = true
+	system.dashboardReady = true
+	system.handlebarUnlocked = true
+
+	return system, mockIO
+}
+
+// Lock command from ready-to-drive must not shut the vehicle down: drive
+// requires an explicit force-lock (Redis force-lock command, or the keycard
+// triple-tap-with-brake gesture).
+func TestHandleStateRequest_LockFromReadyToDrive_Rejected(t *testing.T) {
+	system, _ := rtdLockTestSetup(t)
+
+	err := system.handleStateRequest("lock")
+	if err == nil {
+		t.Fatalf("handleStateRequest(lock) from ReadyToDrive must return error, got nil")
+	}
+	if system.getCurrentState() != types.StateReadyToDrive {
+		t.Errorf("State must remain ReadyToDrive after rejected lock, got %v", system.getCurrentState())
+	}
+}
+
+// EvLock dispatched directly to the FSM in ready-to-drive must be a no-op
+// (the transition has been removed from the definition).
+func TestFSM_EvLockFromReadyToDrive_NoTransition(t *testing.T) {
+	system, _ := rtdLockTestSetup(t)
+
+	system.machine.Send(librefsm.Event{ID: fsm.EvLock})
+	time.Sleep(50 * time.Millisecond)
+
+	if system.getCurrentState() != types.StateReadyToDrive {
+		t.Errorf("EvLock must not transition from ReadyToDrive, got %v", system.getCurrentState())
+	}
+}
+
+// A single keycard tap in ready-to-drive must not shut the vehicle down.
+func TestKeycardAuth_SingleTapFromReadyToDrive_NoShutdown(t *testing.T) {
+	system, _ := rtdLockTestSetup(t)
+
+	if err := system.keycardAuthPassed(); err != nil {
+		t.Fatalf("keycardAuthPassed: %v", err)
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	if system.getCurrentState() != types.StateReadyToDrive {
+		t.Errorf("Single keycard tap must not transition from ReadyToDrive, got %v", system.getCurrentState())
+	}
+}
+
+// EvForceLock from ready-to-drive must transition straight to standby.
+func TestFSM_EvForceLockFromReadyToDrive_GoesToStandby(t *testing.T) {
+	system, _ := rtdLockTestSetup(t)
+
+	if err := system.machine.SendSync(librefsm.Event{ID: fsm.EvForceLock}); err != nil {
+		t.Fatalf("send force-lock: %v", err)
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	if system.getCurrentState() != types.StateStandby {
+		t.Errorf("EvForceLock from ReadyToDrive must reach Standby, got %v", system.getCurrentState())
+	}
+}
+
+// Keycard triple-tap with at least one brake pressed must force-lock from
+// ready-to-drive (the only keycard-driven path that can shut down from drive).
+func TestKeycardAuth_TripleTapWithBrakeFromReadyToDrive_ForceLocks(t *testing.T) {
+	system, mockIO := rtdLockTestSetup(t)
+
+	mockIO.digitalInputs["brake_left"] = true
+
+	for i := 0; i < 3; i++ {
+		if err := system.keycardAuthPassed(); err != nil {
+			t.Fatalf("tap %d: %v", i+1, err)
+		}
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	if system.getCurrentState() != types.StateStandby {
+		t.Errorf("Three keycard taps with brake from RTD must reach Standby, got %v", system.getCurrentState())
+	}
+}

--- a/internal/fsm/definition.go
+++ b/internal/fsm/definition.go
@@ -184,18 +184,16 @@ func NewDefinition(actions Actions) *librefsm.Definition {
 		Transition(StateHopOnLearning, EvHopOnRelease, StateParked).
 		Transition(StateHopOnLearning, EvUnlock, StateParked).
 
-		// From ReadyToDrive
+		// From ReadyToDrive: only force-lock can shut down from drive.
+		// EvLock and a single EvKeycardAuth are intentionally unhandled here:
+		// drive mode requires the rider to either bring the scooter to rest
+		// (kickstand down -> Parked) or trigger an explicit force-lock (Redis
+		// force-lock command, or the triple-tap-with-brake gesture in
+		// keycardAuthPassed which routes to EvForceLock).
 		Transition(StateReadyToDrive, EvKickstandDown, StateParked).
 		Transition(StateReadyToDrive, EvDashboardNotReady, StateParked). // Safety: dashboard disconnect
-		Transition(StateReadyToDrive, EvLock, StateShuttingDown,
-			librefsm.WithGuard(actions.IsSeatboxClosed),
-		).
-		Transition(StateReadyToDrive, EvLock, StateWaitingSeatbox). // Fallback if seatbox open
 		Transition(StateReadyToDrive, EvForceLock, StateStandby,
 			librefsm.WithAction(actions.OnForceLock),
-		).
-		Transition(StateReadyToDrive, EvKeycardAuth, StateShuttingDown, // Requires kickstand down (never true in RTD)
-			librefsm.WithGuard(actions.IsKickstandDown),
 		).
 
 		// From ShuttingDown


### PR DESCRIPTION
`EvLock` from `ready-to-drive` used to transition through `ShuttingDown`
(or `WaitingSeatbox` if the seatbox was open), so a normal
`scooter:state lock` command would shut the scooter down mid-ride. That's
wrong: drive mode should only exit on rider input (kickstand down) or an
explicit force-lock.

A second, dead transition was sitting alongside it: `EvKeycardAuth` on
RTD guarded by `IsKickstandDown`. The kickstand cannot be down in RTD
(that's what triggers the `EvKickstandDown -> Parked` transition right
above it), so the guard was never satisfiable. The comment on the
transition already flagged this.

### Changes

- Drop `EvLock -> ShuttingDown` and `EvLock -> WaitingSeatbox` on `StateReadyToDrive` (`internal/fsm/definition.go`). `EvForceLock -> Standby` stays.
- Drop the dead `EvKeycardAuth -> ShuttingDown` on `StateReadyToDrive`.
- Tighten `handleStateRequest("lock")` (`internal/core/redis_handlers.go`) to reject the request when in RTD with `vehicle must be parked to lock (use force-lock from drive)`, instead of silently dispatching a now-unhandled event.

The two paths that still shut down from drive are unchanged:

- The dedicated force-lock Redis command (`handleForceLockRequest` -> `EvForceLock` -> `Standby`).
- The keycard triple-tap-with-brake gesture in `keycardAuthPassed`, which already routes to `EvForceLock`.

### Tests

Added in `internal/core/system_test.go`:

- `TestHandleStateRequest_LockFromReadyToDrive_Rejected`
- `TestFSM_EvLockFromReadyToDrive_NoTransition`
- `TestKeycardAuth_SingleTapFromReadyToDrive_NoShutdown`
- `TestFSM_EvForceLockFromReadyToDrive_GoesToStandby`
- `TestKeycardAuth_TripleTapWithBrakeFromReadyToDrive_ForceLocks`

Full `internal/core` and `internal/hardware` suites green under `golang:1.24`.

### Test plan

- [x] On bench MDB, get to `ready-to-drive` (kickstand up, dashboard up)
- [x] Single keycard tap: state stays in RTD; service logs `Sending EvKeycardAuth` with no transition
- [ ] `redis-cli lpush scooter:state lock` from RTD: handler returns `vehicle must be parked to lock (use force-lock from drive)`; state stays RTD
- [ ] Triple-tap keycard with one brake pressed: state goes to `stand-by`
- [ ] Drop kickstand: state goes to `parked`; from there `redis-cli lpush scooter:state lock` still shuts down normally