### PR TITLE
refactor(redis): migrate to FaultReporter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	github.com/librescoot/librefsm v0.5.0
-	github.com/librescoot/redis-ipc v0.10.3
+	github.com/librescoot/redis-ipc v0.14.0
 	github.com/redis/go-redis/v9 v9.18.0
 	github.com/warthog618/go-gpiocdev v0.9.1
 	golang.org/x/sys v0.41.0

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBF
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/librescoot/librefsm v0.5.0 h1:6QTzJpIbeY1/4OpzWJeLo1UTsx/iIpkDkxu7t/uDGPc=
 github.com/librescoot/librefsm v0.5.0/go.mod h1:2fZNHRvoQMCPVgGbb31vgawzMaaPyazAPIgQRCiQ+Qw=
-github.com/librescoot/redis-ipc v0.10.3 h1:VAcw2ATlR3E7ntkFVmov3xaakXxomNQk95ch2UQQDPE=
-github.com/librescoot/redis-ipc v0.10.3/go.mod h1:4mRG3+cC+llhsjwyRvNT5bF+bsn0ueaKFf70eqq0IzQ=
+github.com/librescoot/redis-ipc v0.14.0 h1:qXh3LIEoA74pRbrN1nb+a4B2F4lazW6aOPYdlEs/4/E=
+github.com/librescoot/redis-ipc v0.14.0/go.mod h1:uvlJaUd1WzRMjZy7dYCHJ6qphCDeYD5orGK9CLudv1Q=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/messaging/redis.go
+++ b/internal/messaging/redis.go
@@ -59,8 +59,7 @@ type RedisClient struct {
 	powerManagerWatcher *ipc.HashWatcher
 
 	// Fault handling
-	faultSet    *ipc.FaultSet
-	faultStream *ipc.StreamPublisher
+	faults *ipc.FaultReporter
 }
 
 func NewRedisClient(host string, port int, l *logger.Logger, callbacks Callbacks) (*RedisClient, error) {
@@ -95,8 +94,7 @@ func NewRedisClient(host string, port int, l *logger.Logger, callbacks Callbacks
 	r.buttonsPub = client.NewHashPublisher("buttons")
 
 	// Initialize fault handling
-	r.faultSet = client.NewFaultSet("vehicle:fault", "vehicle", "fault")
-	r.faultStream = client.NewStreamPublisher("events:faults", ipc.WithMaxLen(1000))
+	r.faults = client.NewFaultReporter("vehicle")
 
 	return r, nil
 }
@@ -786,56 +784,23 @@ func (r *RedisClient) PublishMessage(channel, message string) error {
 	return nil
 }
 
-// ReportFaultPresent reports a fault as present to Redis
-func (r *RedisClient) ReportFaultPresent(code int, description string, timestamp int64, info string) error {
+// ReportFaultPresent raises a fault. Idempotent.
+func (r *RedisClient) ReportFaultPresent(code int, description string) error {
 	r.logger.Infof("Reporting fault present: code=%d, description=%s", code, description)
-
-	// Add fault code to active faults set
-	if err := r.faultSet.Add(code); err != nil {
-		r.logger.Infof("Failed to add fault to set: %v", err)
+	if err := r.faults.Raise(code, description); err != nil {
+		r.logger.Infof("Failed to raise fault %d: %v", code, err)
 		return err
 	}
-
-	// Add fault event to global event stream with metadata
-	eventData := map[string]any{
-		"group":       "vehicle",
-		"code":        fmt.Sprint(code),
-		"description": description,
-		"ts":          fmt.Sprint(timestamp),
-	}
-	if info != "" {
-		eventData["info"] = info
-	}
-	if _, err := r.faultStream.Add(eventData); err != nil {
-		r.logger.Infof("Failed to add fault to stream: %v", err)
-		return err
-	}
-
-	r.logger.Infof("Successfully reported fault %d as present", code)
 	return nil
 }
 
-// ReportFaultAbsent reports a fault as absent (cleared) to Redis
+// ReportFaultAbsent clears a fault. Idempotent.
 func (r *RedisClient) ReportFaultAbsent(code int) error {
 	r.logger.Infof("Reporting fault absent: code=%d", code)
-
-	// Remove fault code from active faults set
-	if err := r.faultSet.Remove(code); err != nil {
-		r.logger.Infof("Failed to remove fault from set: %v", err)
+	if err := r.faults.Clear(code); err != nil {
+		r.logger.Infof("Failed to clear fault %d: %v", code, err)
 		return err
 	}
-
-	// Add clear event to global event stream (negative code indicates cleared)
-	eventData := map[string]any{
-		"group": "vehicle",
-		"code":  fmt.Sprint(-code), // Negative code indicates fault cleared
-	}
-	if _, err := r.faultStream.Add(eventData); err != nil {
-		r.logger.Infof("Failed to add fault clear to stream: %v", err)
-		return err
-	}
-
-	r.logger.Infof("Successfully reported fault %d as absent", code)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Bumps redis-ipc to v0.14.0 and replaces the `faultSet` + `faultStream` pair with a single `FaultReporter` for group `"vehicle"`. Raise and Clear are idempotent server-side, so set and stream cannot drift.

Drops the unused `ts` / `info` extras from `ReportFaultPresent`: the signature existed but had no callers, and `FaultReporter` doesn't carry arbitrary metadata. Easy to add back as `RaiseWithFields` upstream if a real caller shows up.

## Test plan

- [x] `go vet ./... && go build ./... && go test ./...` green
- [x] ARM cross-compile via `make build`