### PR TITLE
feat(blinker): detect hazard switch as simultaneous left+right press

### DIFF
--- a/internal/core/system.go
+++ b/internal/core/system.go
@@ -1276,6 +1276,7 @@ func (v *VehicleSystem) handleBlinkerChange(channel string, value bool) error {
 	}
 
 	if switchState == "off" {
+		v.blinkerState = BlinkerOff
 		if err := v.io.PlayPwmCue(cue); err != nil {
 			return err
 		}
@@ -1296,8 +1297,10 @@ func (v *VehicleSystem) handleBlinkerChange(channel string, value bool) error {
 		return v.redis.SetBlinkerState(switchState, 0)
 	}
 
-	// Blinker active: update LED state based on combined switch state, then
-	// publish the PUBSUB event for the triggering channel based on value.
+	// Blinker active: update LED state based on combined switch state, write
+	// Redis switch state, then publish the PUBSUB event. Writing Redis state
+	// before publishing matches the off-path ordering so consumers that read
+	// Redis in response to the event always see the updated switch state.
 	// Publishing channel+value (not switchState) ensures consumers always
 	// receive the correct edge — e.g. blinker:right:off when one side of a
 	// hazard pair is released, even though the combined state transitions to
@@ -1311,6 +1314,10 @@ func (v *VehicleSystem) handleBlinkerChange(channel string, value bool) error {
 		v.blinkerState = BlinkerLeft
 	}
 
+	if err := v.redis.SetBlinkerSwitch(switchState); err != nil {
+		return err
+	}
+
 	position := strings.TrimPrefix(channel, "blinker_")
 	onOff := "on"
 	if !value {
@@ -1320,10 +1327,6 @@ func (v *VehicleSystem) handleBlinkerChange(channel string, value bool) error {
 	if err := v.redis.PublishButtonEvent(evt); err != nil {
 		v.logger.Infof("Failed to publish blinker button event %s: %v", evt, err)
 		// Continue with normal processing even if PUBSUB fails
-	}
-
-	if err := v.redis.SetBlinkerSwitch(switchState); err != nil {
-		return err
 	}
 
 	// Start blinker routine. runBlinker captures blinker:start_nanos itself

--- a/internal/core/system.go
+++ b/internal/core/system.go
@@ -1226,8 +1226,21 @@ func (v *VehicleSystem) stopBlinker() {
 }
 
 func (v *VehicleSystem) handleBlinkerChange(channel string, value bool) error {
+	// Capture blinker state before stopping so the peer-read fallback below
+	// uses the pre-stop value regardless of what stopBlinker does internally.
+	prevBlinkerState := v.blinkerState
+
 	// Stop any existing blinker routine
 	v.stopBlinker()
+
+	// Build the PUBSUB event string once from the triggering channel and value
+	// so both the off path and the active path use the same format.
+	position := strings.TrimPrefix(channel, "blinker_")
+	onOff := "on"
+	if !value {
+		onOff = "off"
+	}
+	evt := fmt.Sprintf("blinker:%s:%s", position, onOff)
 
 	// Determine the combined state of both blinker switches. io.go updates
 	// activeKeys for each event before firing the callback, so by the time
@@ -1242,7 +1255,7 @@ func (v *VehicleSystem) handleBlinkerChange(channel string, value bool) error {
 		blinkerRight = value
 		if leftVal, err := v.io.ReadDigitalInput("blinker_left"); err != nil {
 			v.logger.Warnf("Failed to read blinker_left for hazard detection, falling back to last known state: %v", err)
-			blinkerLeft = v.blinkerState == BlinkerLeft || v.blinkerState == BlinkerBoth
+			blinkerLeft = prevBlinkerState == BlinkerLeft || prevBlinkerState == BlinkerBoth
 		} else {
 			blinkerLeft = leftVal
 		}
@@ -1250,7 +1263,7 @@ func (v *VehicleSystem) handleBlinkerChange(channel string, value bool) error {
 		blinkerLeft = value
 		if rightVal, err := v.io.ReadDigitalInput("blinker_right"); err != nil {
 			v.logger.Warnf("Failed to read blinker_right for hazard detection, falling back to last known state: %v", err)
-			blinkerRight = v.blinkerState == BlinkerRight || v.blinkerState == BlinkerBoth
+			blinkerRight = prevBlinkerState == BlinkerRight || prevBlinkerState == BlinkerBoth
 		} else {
 			blinkerRight = rightVal
 		}
@@ -1284,14 +1297,8 @@ func (v *VehicleSystem) handleBlinkerChange(channel string, value bool) error {
 			return err
 		}
 		// Also publish the button event directly via PUBSUB for immediate handling
-		var evtOff string
-		if channel == "blinker_right" {
-			evtOff = "blinker:right:off"
-		} else {
-			evtOff = "blinker:left:off"
-		}
-		if err := v.redis.PublishButtonEvent(evtOff); err != nil {
-			v.logger.Infof("Failed to publish blinker button event %s: %v", evtOff, err)
+		if err := v.redis.PublishButtonEvent(evt); err != nil {
+			v.logger.Infof("Failed to publish blinker button event %s: %v", evt, err)
 			// Continue with normal processing even if PUBSUB fails
 		}
 		return v.redis.SetBlinkerState(switchState, 0)
@@ -1318,12 +1325,6 @@ func (v *VehicleSystem) handleBlinkerChange(channel string, value bool) error {
 		return err
 	}
 
-	position := strings.TrimPrefix(channel, "blinker_")
-	onOff := "on"
-	if !value {
-		onOff = "off"
-	}
-	evt := fmt.Sprintf("blinker:%s:%s", position, onOff)
 	if err := v.redis.PublishButtonEvent(evt); err != nil {
 		v.logger.Infof("Failed to publish blinker button event %s: %v", evt, err)
 		// Continue with normal processing even if PUBSUB fails

--- a/internal/core/system.go
+++ b/internal/core/system.go
@@ -1229,61 +1229,101 @@ func (v *VehicleSystem) handleBlinkerChange(channel string, value bool) error {
 	// Stop any existing blinker routine
 	v.stopBlinker()
 
-	// Update Redis switch state first
+	// Determine the combined state of both blinker switches. io.go updates
+	// activeKeys for each event before firing the callback, so by the time
+	// event 2's callback runs, event 1's key is already reflected in the
+	// cache. ReadDigitalInput (activeKeys) is therefore more reliable than
+	// ReadDigitalInputDirect (EVIOCGKEY ioctl), which races against the
+	// kernel's second GPIO interrupt handler.
+	blinkerRight := false
+	blinkerLeft := false
+	if channel == "blinker_right" {
+		blinkerRight = value
+		if leftVal, err := v.io.ReadDigitalInput("blinker_left"); err != nil {
+			v.logger.Warnf("Failed to read blinker_left for hazard detection: %v", err)
+		} else {
+			blinkerLeft = leftVal
+		}
+	} else {
+		blinkerLeft = value
+		if rightVal, err := v.io.ReadDigitalInput("blinker_right"); err != nil {
+			v.logger.Warnf("Failed to read blinker_right for hazard detection: %v", err)
+		} else {
+			blinkerRight = rightVal
+		}
+	}
+
 	var switchState string
 	var cue int
-
-	if !value {
-		// Both blinkers off
+	switch {
+	case blinkerLeft && blinkerRight:
+		switchState = "both"
+		cue = 12 // LED_BLINK_BOTH
+	case blinkerRight:
+		switchState = "right"
+		cue = 11 // LED_BLINK_RIGHT
+	case blinkerLeft:
+		switchState = "left"
+		cue = 10 // LED_BLINK_LEFT
+	default:
 		switchState = "off"
 		cue = 9 // LED_BLINK_NONE
+	}
+
+	if switchState == "off" {
 		if err := v.io.PlayPwmCue(cue); err != nil {
 			return err
 		}
 		if err := v.redis.SetBlinkerSwitch(switchState); err != nil {
 			return err
 		}
-
 		// Also publish the button event directly via PUBSUB for immediate handling
+		var evtOff string
 		if channel == "blinker_right" {
-			if err := v.redis.PublishButtonEvent("blinker:right:off"); err != nil {
+			evtOff = "blinker:right:off"
+		} else {
+			evtOff = "blinker:left:off"
+		}
+		if err := v.redis.PublishButtonEvent(evtOff); err != nil {
+			v.logger.Infof("Failed to publish blinker button event: %v", err)
+			// Continue with normal processing even if PUBSUB fails
+		}
+		return v.redis.SetBlinkerState(switchState, 0)
+	}
+
+	// Blinker active: set state and publish appropriate button event.
+	// For hazard (both switches active simultaneously) we publish the event
+	// for the triggering channel so that consumers see both blinker:left:on
+	// and blinker:right:on arriving in quick succession, which is the correct
+	// representation of hazard without introducing a new event type.
+	switch switchState {
+	case "both":
+		v.blinkerState = BlinkerBoth
+		if channel == "blinker_right" {
+			if err := v.redis.PublishButtonEvent("blinker:right:on"); err != nil {
 				v.logger.Infof("Failed to publish blinker right button event: %v", err)
 				// Continue with normal processing even if PUBSUB fails
 			}
 		} else {
-			if err := v.redis.PublishButtonEvent("blinker:left:off"); err != nil {
+			if err := v.redis.PublishButtonEvent("blinker:left:on"); err != nil {
 				v.logger.Infof("Failed to publish blinker left button event: %v", err)
 				// Continue with normal processing even if PUBSUB fails
 			}
 		}
-
-		return v.redis.SetBlinkerState(switchState, 0)
-	}
-
-	// Handle blinker activation
-	if channel == "blinker_right" {
-		switchState = "right"
-		cue = 11 // LED_BLINK_RIGHT
+	case "right":
 		v.blinkerState = BlinkerRight
-
-		// Publish button press event via PUBSUB for immediate handling
 		if err := v.redis.PublishButtonEvent("blinker:right:on"); err != nil {
 			v.logger.Infof("Failed to publish blinker right button event: %v", err)
 			// Continue with normal processing even if PUBSUB fails
 		}
-	} else {
-		switchState = "left"
-		cue = 10 // LED_BLINK_LEFT
+	case "left":
 		v.blinkerState = BlinkerLeft
-
-		// Publish button press event via PUBSUB for immediate handling
 		if err := v.redis.PublishButtonEvent("blinker:left:on"); err != nil {
 			v.logger.Infof("Failed to publish blinker left button event: %v", err)
 			// Continue with normal processing even if PUBSUB fails
 		}
 	}
 
-	// Set switch state when button is pressed
 	if err := v.redis.SetBlinkerSwitch(switchState); err != nil {
 		return err
 	}

--- a/internal/core/system.go
+++ b/internal/core/system.go
@@ -1237,20 +1237,23 @@ func (v *VehicleSystem) handleBlinkerChange(channel string, value bool) error {
 	// kernel's second GPIO interrupt handler.
 	blinkerRight := false
 	blinkerLeft := false
-	if channel == "blinker_right" {
+	switch channel {
+	case "blinker_right":
 		blinkerRight = value
 		if leftVal, err := v.io.ReadDigitalInput("blinker_left"); err != nil {
 			v.logger.Warnf("Failed to read blinker_left for hazard detection: %v", err)
 		} else {
 			blinkerLeft = leftVal
 		}
-	} else {
+	case "blinker_left":
 		blinkerLeft = value
 		if rightVal, err := v.io.ReadDigitalInput("blinker_right"); err != nil {
 			v.logger.Warnf("Failed to read blinker_right for hazard detection: %v", err)
 		} else {
 			blinkerRight = rightVal
 		}
+	default:
+		return fmt.Errorf("unexpected blinker channel: %s", channel)
 	}
 
 	var switchState string
@@ -1291,37 +1294,29 @@ func (v *VehicleSystem) handleBlinkerChange(channel string, value bool) error {
 		return v.redis.SetBlinkerState(switchState, 0)
 	}
 
-	// Blinker active: set state and publish appropriate button event.
-	// For hazard (both switches active simultaneously) we publish the event
-	// for the triggering channel so that consumers see both blinker:left:on
-	// and blinker:right:on arriving in quick succession, which is the correct
-	// representation of hazard without introducing a new event type.
+	// Blinker active: update LED state based on combined switch state, then
+	// publish the PUBSUB event for the triggering channel based on value.
+	// Publishing channel+value (not switchState) ensures consumers always
+	// receive the correct edge — e.g. blinker:right:off when one side of a
+	// hazard pair is released, even though the combined state transitions to
+	// "left" rather than "off".
 	switch switchState {
 	case "both":
 		v.blinkerState = BlinkerBoth
-		if channel == "blinker_right" {
-			if err := v.redis.PublishButtonEvent("blinker:right:on"); err != nil {
-				v.logger.Infof("Failed to publish blinker right button event: %v", err)
-				// Continue with normal processing even if PUBSUB fails
-			}
-		} else {
-			if err := v.redis.PublishButtonEvent("blinker:left:on"); err != nil {
-				v.logger.Infof("Failed to publish blinker left button event: %v", err)
-				// Continue with normal processing even if PUBSUB fails
-			}
-		}
 	case "right":
 		v.blinkerState = BlinkerRight
-		if err := v.redis.PublishButtonEvent("blinker:right:on"); err != nil {
-			v.logger.Infof("Failed to publish blinker right button event: %v", err)
-			// Continue with normal processing even if PUBSUB fails
-		}
 	case "left":
 		v.blinkerState = BlinkerLeft
-		if err := v.redis.PublishButtonEvent("blinker:left:on"); err != nil {
-			v.logger.Infof("Failed to publish blinker left button event: %v", err)
-			// Continue with normal processing even if PUBSUB fails
-		}
+	}
+
+	position := strings.TrimPrefix(channel, "blinker_")
+	onOff := "on"
+	if !value {
+		onOff = "off"
+	}
+	if err := v.redis.PublishButtonEvent(fmt.Sprintf("blinker:%s:%s", position, onOff)); err != nil {
+		v.logger.Infof("Failed to publish blinker button event: %v", err)
+		// Continue with normal processing even if PUBSUB fails
 	}
 
 	if err := v.redis.SetBlinkerSwitch(switchState); err != nil {

--- a/internal/core/system.go
+++ b/internal/core/system.go
@@ -1241,14 +1241,16 @@ func (v *VehicleSystem) handleBlinkerChange(channel string, value bool) error {
 	case "blinker_right":
 		blinkerRight = value
 		if leftVal, err := v.io.ReadDigitalInput("blinker_left"); err != nil {
-			v.logger.Warnf("Failed to read blinker_left for hazard detection: %v", err)
+			v.logger.Warnf("Failed to read blinker_left for hazard detection, falling back to last known state: %v", err)
+			blinkerLeft = v.blinkerState == BlinkerLeft || v.blinkerState == BlinkerBoth
 		} else {
 			blinkerLeft = leftVal
 		}
 	case "blinker_left":
 		blinkerLeft = value
 		if rightVal, err := v.io.ReadDigitalInput("blinker_right"); err != nil {
-			v.logger.Warnf("Failed to read blinker_right for hazard detection: %v", err)
+			v.logger.Warnf("Failed to read blinker_right for hazard detection, falling back to last known state: %v", err)
+			blinkerRight = v.blinkerState == BlinkerRight || v.blinkerState == BlinkerBoth
 		} else {
 			blinkerRight = rightVal
 		}
@@ -1288,7 +1290,7 @@ func (v *VehicleSystem) handleBlinkerChange(channel string, value bool) error {
 			evtOff = "blinker:left:off"
 		}
 		if err := v.redis.PublishButtonEvent(evtOff); err != nil {
-			v.logger.Infof("Failed to publish blinker button event: %v", err)
+			v.logger.Infof("Failed to publish blinker button event %s: %v", evtOff, err)
 			// Continue with normal processing even if PUBSUB fails
 		}
 		return v.redis.SetBlinkerState(switchState, 0)
@@ -1314,8 +1316,9 @@ func (v *VehicleSystem) handleBlinkerChange(channel string, value bool) error {
 	if !value {
 		onOff = "off"
 	}
-	if err := v.redis.PublishButtonEvent(fmt.Sprintf("blinker:%s:%s", position, onOff)); err != nil {
-		v.logger.Infof("Failed to publish blinker button event: %v", err)
+	evt := fmt.Sprintf("blinker:%s:%s", position, onOff)
+	if err := v.redis.PublishButtonEvent(evt); err != nil {
+		v.logger.Infof("Failed to publish blinker button event %s: %v", evt, err)
 		// Continue with normal processing even if PUBSUB fails
 	}
 

--- a/internal/core/system.go
+++ b/internal/core/system.go
@@ -1259,7 +1259,7 @@ func (v *VehicleSystem) handleBlinkerChange(channel string, value bool) error {
 			blinkerRight = rightVal
 		}
 	default:
-		return fmt.Errorf("unexpected blinker channel: %s", channel)
+		return fmt.Errorf("unexpected blinker channel: %q", channel)
 	}
 
 	// Build PUBSUB event string after channel validation so position is

--- a/internal/core/system.go
+++ b/internal/core/system.go
@@ -1233,15 +1233,6 @@ func (v *VehicleSystem) handleBlinkerChange(channel string, value bool) error {
 	// Stop any existing blinker routine
 	v.stopBlinker()
 
-	// Build the PUBSUB event string once from the triggering channel and value
-	// so both the off path and the active path use the same format.
-	position := strings.TrimPrefix(channel, "blinker_")
-	onOff := "on"
-	if !value {
-		onOff = "off"
-	}
-	evt := fmt.Sprintf("blinker:%s:%s", position, onOff)
-
 	// Determine the combined state of both blinker switches. io.go updates
 	// activeKeys for each event before firing the callback, so by the time
 	// event 2's callback runs, event 1's key is already reflected in the
@@ -1271,6 +1262,16 @@ func (v *VehicleSystem) handleBlinkerChange(channel string, value bool) error {
 		return fmt.Errorf("unexpected blinker channel: %s", channel)
 	}
 
+	// Build PUBSUB event string after channel validation so position is
+	// guaranteed to be "left" or "right", never a TrimPrefix residue from an
+	// unexpected channel value.
+	position := strings.TrimPrefix(channel, "blinker_")
+	onOff := "on"
+	if !value {
+		onOff = "off"
+	}
+	evt := fmt.Sprintf("blinker:%s:%s", position, onOff)
+
 	var switchState string
 	var cue int
 	switch {
@@ -1289,7 +1290,6 @@ func (v *VehicleSystem) handleBlinkerChange(channel string, value bool) error {
 	}
 
 	if switchState == "off" {
-		v.blinkerState = BlinkerOff
 		if err := v.io.PlayPwmCue(cue); err != nil {
 			return err
 		}
@@ -1301,26 +1301,21 @@ func (v *VehicleSystem) handleBlinkerChange(channel string, value bool) error {
 			v.logger.Infof("Failed to publish blinker button event %s: %v", evt, err)
 			// Continue with normal processing even if PUBSUB fails
 		}
-		return v.redis.SetBlinkerState(switchState, 0)
+		if err := v.redis.SetBlinkerState(switchState, 0); err != nil {
+			return err
+		}
+		// Only update in-memory state after all hardware and Redis writes
+		// succeed so the fallback read in future events reflects reality.
+		v.blinkerState = BlinkerOff
+		return nil
 	}
 
-	// Blinker active: update LED state based on combined switch state, write
-	// Redis switch state, then publish the PUBSUB event. Writing Redis state
-	// before publishing matches the off-path ordering so consumers that read
-	// Redis in response to the event always see the updated switch state.
-	// Publishing channel+value (not switchState) ensures consumers always
-	// receive the correct edge — e.g. blinker:right:off when one side of a
-	// hazard pair is released, even though the combined state transitions to
-	// "left" rather than "off".
-	switch switchState {
-	case "both":
-		v.blinkerState = BlinkerBoth
-	case "right":
-		v.blinkerState = BlinkerRight
-	case "left":
-		v.blinkerState = BlinkerLeft
-	}
-
+	// Blinker active: write Redis switch state before publishing the PUBSUB
+	// event so consumers that read Redis in response to the event always see
+	// the updated switch state. Publishing channel+value (not switchState)
+	// ensures consumers always receive the correct edge — e.g. blinker:right:off
+	// when one side of a hazard pair is released, even though the combined
+	// state transitions to "left" rather than "off".
 	if err := v.redis.SetBlinkerSwitch(switchState); err != nil {
 		return err
 	}
@@ -1328,6 +1323,17 @@ func (v *VehicleSystem) handleBlinkerChange(channel string, value bool) error {
 	if err := v.redis.PublishButtonEvent(evt); err != nil {
 		v.logger.Infof("Failed to publish blinker button event %s: %v", evt, err)
 		// Continue with normal processing even if PUBSUB fails
+	}
+
+	// Only update in-memory blinker state after all Redis writes succeed so
+	// the fallback read in future events reflects actual committed state.
+	switch switchState {
+	case "both":
+		v.blinkerState = BlinkerBoth
+	case "right":
+		v.blinkerState = BlinkerRight
+	case "left":
+		v.blinkerState = BlinkerLeft
 	}
 
 	// Start blinker routine. runBlinker captures blinker:start_nanos itself


### PR DESCRIPTION
The stock blinker switch only supports left and right. This adds support for an upgraded switch assembly that includes a physical hazard button, wired to both blinker_left and blinker_right GPIO inputs simultaneously. The original code had no concept of both switches being active at the same time, so pressing the hazard button would only register as left or right — never both.

This change adds hazard light detection to handleBlinkerChange: when a blinker event fires, the peer switch's state is read from the activeKeys cache (ReadDigitalInput). Since io.go updates activeKeys before firing each callback, the second event's handler always sees the first switch as already active. When both are active, the combined state is "both" (LED cue 12), which drives the hazard lights.

Tested on two scooters:
- Stock scooter (standard blinker switch) — left, right, off, and hop-on mode all behave as before
- Upgraded scooter (switch assembly with physical hazard button) — hazard lights activate correctly; all blinker combinations verified

All existing tests pass (go test ./...).